### PR TITLE
Gracefully handle missing disciplinary data in stats

### DIFF
--- a/tests/test_aggregate_team_stats.py
+++ b/tests/test_aggregate_team_stats.py
@@ -1,0 +1,30 @@
+import sys
+import pathlib
+import pandas as pd
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from utils.poisson_utils.core import aggregate_team_stats
+
+
+def test_aggregate_team_stats_handles_missing_columns():
+    df = pd.DataFrame({
+        'Date': ['2024-01-01', '2024-01-02'],
+        'HomeTeam': ['A', 'B'],
+        'AwayTeam': ['B', 'A'],
+        'FTHG': [1, 2],
+        'FTAG': [0, 1],
+        'HS': [5, 6],
+        'AS': [3, 4],
+        'HST': [2, 3],
+        'AST': [1, 2],
+        'HC': [1, 2],
+        'AC': [3, 4],
+        # Columns HY, AY, HR, AR, HF, AF intentionally omitted
+    })
+
+    stats = aggregate_team_stats(df)
+
+    assert 'Žluté' in stats.columns
+    assert 'Červené' in stats.columns
+    assert stats.loc['A', 'Žluté'] == 0
+    assert stats.loc['B', 'Červené'] == 0

--- a/utils/poisson_utils/core.py
+++ b/utils/poisson_utils/core.py
@@ -46,25 +46,25 @@ def load_data(file_path: str) -> pd.DataFrame:
 #     })
 #     return team_stats
 
-def aggregate_team_stats(df):
+def aggregate_team_stats(df: pd.DataFrame) -> pd.DataFrame:
     """Agreguje statistiky za všechny zápasy (doma i venku) pro každý tým."""
-    teams = pd.concat([df['HomeTeam'], df['AwayTeam']]).unique()
+    df = df.copy()
+    for col in ["HY", "AY", "HR", "AR", "HF", "AF"]:
+        if col not in df.columns:
+            df[col] = 0
+    teams = pd.concat([df["HomeTeam"], df["AwayTeam"]]).unique()
     records = []
-
     for team in teams:
-        home = df[df['HomeTeam'] == team]
-        away = df[df['AwayTeam'] == team]
-
-        goals = pd.concat([home['FTHG'], away['FTAG']])
-        conceded = pd.concat([home['FTAG'], away['FTHG']])
-        shots = pd.concat([home['HS'], away['AS']])
-        shots_on_target = pd.concat([home['HST'], away['AST']])
-        corners = pd.concat([home['HC'], away['AC']])
-        yellows = pd.concat([home['HY'], away['AY']])
-        reds = pd.concat([home['HR'], away['AR']])
-        fouls = pd.concat([home['HF'], away['AF']])
-
-
+        home = df[df["HomeTeam"] == team]
+        away = df[df["AwayTeam"] == team]
+        goals = pd.concat([home["FTHG"], away["FTAG"]])
+        conceded = pd.concat([home["FTAG"], away["FTHG"]])
+        shots = pd.concat([home["HS"], away["AS"]])
+        shots_on_target = pd.concat([home["HST"], away["AST"]])
+        corners = pd.concat([home["HC"], away["AC"]])
+        yellows = pd.concat([home["HY"], away["AY"]])
+        reds = pd.concat([home["HR"], away["AR"]])
+        fouls = pd.concat([home["HF"], away["AF"]])
         records.append({
             "Tým": team,
             "Góly": goals.mean(),
@@ -75,12 +75,8 @@ def aggregate_team_stats(df):
             "Žluté": yellows.mean(),
             "Červené": reds.mean(),
             "Fauly": fouls.mean()
-
         })
-
     df_stats = pd.DataFrame(records).set_index("Tým")
-
-    print(df_stats.columns)
     return df_stats
 
 


### PR DESCRIPTION
## Summary
- make team stats aggregation robust to datasets missing card/foul columns
- add regression test for handling absent disciplinary columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689613fbb3108329969c18188540568a