### PR TITLE
Refactor utilities into modular structure

### DIFF
--- a/sections/match_prediction_section - kopie.py
+++ b/sections/match_prediction_section - kopie.py
@@ -13,7 +13,7 @@ from utils.poisson_utils import (
 from utils.frontend_utils import display_team_status_table
 from utils.poisson_utils.match_style import tempo_tag
 from utils.export_utils import generate_excel_analysis_export
-from utils.utils_warnings import (
+from utils.team_analysis import (
     scoreline_variance_warning,
     combined_form_tempo_warning,
     conflict_style_warning,

--- a/sections/match_prediction_section.py
+++ b/sections/match_prediction_section.py
@@ -15,7 +15,7 @@ from utils.poisson_utils import (
 from utils.frontend_utils import display_team_status_table
 from utils.poisson_utils.match_style import tempo_tag
 from utils.export_utils import generate_excel_analysis_export
-from utils.utils_warnings import (
+from utils.team_analysis import (
     scoreline_variance_warning,
     combined_form_tempo_warning,
     conflict_style_warning,

--- a/utils/data_preparation.py
+++ b/utils/data_preparation.py
@@ -1,0 +1,31 @@
+import pandas as pd
+
+
+def load_data(file_path):
+    df = pd.read_csv(file_path)
+    df['Date'] = pd.to_datetime(df['Date'], dayfirst=True, errors='coerce')
+    df = df.dropna(subset=['FTHG', 'FTAG', 'Date'])
+    df = df.sort_values('Date')
+    return df
+
+
+def prepare_df(df):
+    """Základní úprava dat: kopírování, převod datumu, odstranění nevalidních řádků, seřazení podle data."""
+    df = df.copy()
+    df['Date'] = pd.to_datetime(df['Date'], dayfirst=True, errors='coerce')
+    df = df.dropna(subset=['Date'])
+    df = df.sort_values('Date')
+    return df
+
+
+def detect_current_season(df):
+    df = prepare_df(df)
+    dates = df['Date'].drop_duplicates().sort_values().reset_index(drop=True)
+    date_diffs = dates.diff().fillna(pd.Timedelta(days=0))
+    season_breaks = dates[date_diffs > pd.Timedelta(days=30)].reset_index(drop=True)
+    if not season_breaks.empty:
+        season_start = season_breaks.iloc[-1]
+    else:
+        season_start = dates.iloc[0]
+    print(season_start)
+    return df[df['Date'] >= season_start], season_start

--- a/utils/poisson_utils/match_style.py
+++ b/utils/poisson_utils/match_style.py
@@ -1,8 +1,7 @@
 import pandas as pd
 import numpy as np
 
-from ..utils_warnings import classify_team_strength  # pokud není globálně importováno
-from .core import prepare_df
+from .core import prepare_df, classify_team_strength
 
 
 def calculate_match_tempo(df: pd.DataFrame, team: str, opponent_elo: float, is_home: bool, elo_dict: dict, last_n: int = 10) -> dict:

--- a/utils/poisson_utils/team_analysis.py
+++ b/utils/poisson_utils/team_analysis.py
@@ -4,7 +4,6 @@ from scipy.stats import poisson
 import streamlit as st
 from .core import prepare_df,get_last_n_matches, calculate_points,poisson_over25_probability,expected_goals_vs_similar_elo_weighted 
 from .xg import calculate_team_pseudo_xg
-from utils.utils_warnings import detect_overperformance_and_momentum
 
 def calculate_clean_sheets(df: pd.DataFrame, team: str) -> float:
     """Vrací procento zápasů, kdy tým udržel čisté konto."""

--- a/utils/probabilities.py
+++ b/utils/probabilities.py
@@ -1,0 +1,81 @@
+import numpy as np
+import pandas as pd
+from scipy.stats import poisson
+import matplotlib.pyplot as plt
+
+
+def poisson_prediction(home_exp, away_exp, max_goals=6):
+    matrix = np.zeros((max_goals + 1, max_goals + 1))
+    for i in range(max_goals + 1):
+        for j in range(max_goals + 1):
+            matrix[i][j] = poisson.pmf(i, home_exp) * poisson.pmf(j, away_exp)
+    return matrix
+
+
+def match_outcomes_prob(matrix):
+    home_win = np.tril(matrix, -1).sum()
+    draw = np.trace(matrix)
+    away_win = np.triu(matrix, 1).sum()
+    return {
+        'Home Win': round(home_win * 100, 2),
+        'Draw': round(draw * 100, 2),
+        'Away Win': round(away_win * 100, 2)
+    }
+
+
+def over_under_prob(matrix, line=2.5):
+    prob_over = sum(
+        matrix[i][j]
+        for i in range(matrix.shape[0])
+        for j in range(matrix.shape[1])
+        if i + j > line
+    )
+    return {
+        'Over 2.5': round(prob_over * 100, 2),
+        'Under 2.5': round((1 - prob_over) * 100, 2)
+    }
+
+
+def btts_prob(matrix):
+    btts = sum(
+        matrix[i][j]
+        for i in range(1, matrix.shape[0])
+        for j in range(1, matrix.shape[1])
+    )
+    return {'BTTS Yes': round(btts * 100, 2), 'BTTS No': round((1 - btts) * 100, 2)}
+
+
+def prob_to_odds(prob_percent):
+    if prob_percent <= 0:
+        return "∞"
+    return round(100 / prob_percent, 2)
+
+
+def generate_score_table_df(matrix, home_team, away_team):
+    df = pd.DataFrame(matrix * 100)
+    df.index.name = f"{home_team} góly"
+    df.columns.name = f"{away_team} góly"
+    styled = (
+        df.style
+        .format("{:.1f} %")
+        .background_gradient(cmap="YlOrRd", axis=None)
+        .set_properties(**{"text-align": "center", "font-size": "11px"})
+    )
+    return styled
+
+
+def get_top_scorelines(matrix, top_n=5):
+    score_probs = [((i, j), matrix[i][j]) for i in range(matrix.shape[0]) for j in range(matrix.shape[1])]
+    score_probs.sort(key=lambda x: x[1], reverse=True)
+    return score_probs[:top_n]
+
+
+def plot_top_scorelines(score_probs, home_team, away_team):
+    labels = [f"{a}:{b}" for (a, b), _ in score_probs]
+    values = [round(p * 100, 2) for _, p in score_probs]
+    fig, ax = plt.subplots()
+    ax.bar(labels, values, color='skyblue')
+    ax.set_title(f"Top skóre: {home_team} vs {away_team}")
+    ax.set_xlabel("Skóre")
+    ax.set_ylabel("Pravděpodobnost (%)")
+    return fig


### PR DESCRIPTION
## Summary
- split former utils_warnings functions into dedicated modules: data_preparation, probabilities and team_analysis
- update imports to use new module paths and remove obsolete file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689623071c3c8329a0b520e0f5f84f3c