### PR TITLE
Improve season detection for league data

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,6 +34,14 @@ league_files = {
     "T1 (Super League)": "data/T1_combined_full_updated.csv",
 }
 
+# Months when each league typically starts a new season. Used as a
+# fallback when no large break between matches is detected.
+LEAGUE_START_MONTH = {
+    "B1": 7,  # Jupiler League begins in July
+    "D2": 7,  # 2. Bundesliga kicks off in July
+    # Other leagues default to August
+}
+
 # --- Sidebar: Správa dat ---
 with st.sidebar.expander("🔧 Správa dat"):
     if st.button("🔄 Aktualizovat data z webu"):
@@ -77,7 +85,9 @@ league_file = league_files[league_name]
 def load_and_prepare(file_path):
     df = load_data(file_path)
     validate_dataset(df)
-    season_df, _ = detect_current_season(df)
+    league_code = file_path.split('/')[-1].split('_')[0]
+    start_month = LEAGUE_START_MONTH.get(league_code, 8)
+    season_df, _ = detect_current_season(df, start_month=start_month)
     team_strengths, _, _ = calculate_team_strengths(df)
     season_df = calculate_gii_zscore(season_df)
     gii_dict = get_team_average_gii(season_df)

--- a/sections/match_prediction_section.py
+++ b/sections/match_prediction_section.py
@@ -86,7 +86,9 @@ def compute_match_inputs(
     xg_home = xg_dict.get(home_team, {"xG_home": 0})
     xg_away = xg_dict.get(away_team, {"xG_away": 0})
 
-    expected_gii = round((gii_dict.get(home_team, 0) + gii_dict.get(away_team, 0)) / 2, 2)
+    gii_home = gii_dict.get(home_team)
+    gii_away = gii_dict.get(away_team)
+    expected_gii = round(((gii_home or 0) + (gii_away or 0)) / 2, 2)
     expected_tempo = expected_match_tempo(
         df,
         home_team,

--- a/sections/overview_section.py
+++ b/sections/overview_section.py
@@ -62,7 +62,7 @@ def render_league_overview(season_df, league_name, gii_dict):
         "Čistá konta %": team_stats.index.map(lambda t: f"{calculate_clean_sheets(season_df, t)}%"),
         "Over 2.5 %": team_stats.index.map(over25).astype(str) + "%",
         "BTTS %": team_stats.index.map(btts).astype(str) + "%",
-        "Intenzita": team_stats.index.map(lambda t: intensity_score_to_emoji(gii_dict.get(t, 0)))
+        "Intenzita": team_stats.index.map(lambda t: intensity_score_to_emoji(gii_dict.get(t)))
     })
 
     summary_table = summary_table.sort_values("Body", ascending=False).reset_index(drop=True)

--- a/utils/poisson_utils/match_style.py
+++ b/utils/poisson_utils/match_style.py
@@ -391,8 +391,14 @@ def calculate_team_styles(df: pd.DataFrame) -> tuple:
 
     return off_df, def_df
 
-def intensity_score_to_emoji(score: float) -> str:
-    """Převede skóre GII na emoji."""
+def intensity_score_to_emoji(score: float | None) -> str:
+    """Převede skóre GII na emoji.
+
+    Pokud není k dispozici dostatek dat (``score`` je ``None``),
+    vrátí prázdný řetězec místo vyhazování výjimky.
+    """
+    if score is None:
+        return ""
     if score > 1.0:
         return "🔥"
     elif score > 0.3:


### PR DESCRIPTION
## Summary
- Make `detect_current_season` more robust by combining gap-based season break detection with a configurable fallback start month
- Ignore future fixtures when determining the current season to prevent premature season shifts
- Handle early-start leagues like Jupiler League and 2. Bundesliga by specifying a July fallback start month
- Avoid crashes from missing intensity metrics by safely handling `None` values in GII lookups

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_689658be7a288329bcf313bb9bb852e3