### PR TITLE
Refactor team comparison metrics

### DIFF
--- a/sections/team_detail_section.py
+++ b/sections/team_detail_section.py
@@ -91,31 +91,28 @@ def render_team_detail(
     all_matches = pd.concat([home, away])
 
     if compare_team and compare_team != "Žádný" and compare_team != team:
-        stats_all = calculate_advanced_team_metrics(all_matches)
-        stats_home = calculate_advanced_team_metrics(home, is_home=True)
-        stats_away = calculate_advanced_team_metrics(away, is_home=False)
-
         compare_df = _apply_time_filter(original_df, compare_team)
         compare_home = compare_df[compare_df['HomeTeam'] == compare_team]
         compare_away = compare_df[compare_df['AwayTeam'] == compare_team]
         compare_matches = pd.concat([compare_home, compare_away])
 
-        compare_stats_all = calculate_advanced_team_metrics(compare_matches)
-        compare_stats_home = calculate_advanced_team_metrics(compare_home, is_home=True)
-        compare_stats_away = calculate_advanced_team_metrics(compare_away, is_home=False)
+        total_df = pd.concat([all_matches, compare_matches])
+        home_df = pd.concat([home, compare_home])
+        away_df = pd.concat([away, compare_away])
 
-        if team in stats_all.index and compare_team in compare_stats_all.index:
-            render_team_comparison_section(
-                team, compare_team,
-                stats_all.loc[team], stats_home.loc[team], stats_away.loc[team],
-                compare_stats_all.loc[compare_team],
-                compare_stats_home.loc[compare_team],
-                compare_stats_away.loc[compare_team]
-            )
-            return
-        else:
+        stats_total = generate_team_comparison(total_df, team, compare_team)
+        stats_home = generate_team_comparison(home_df, team, compare_team)
+        stats_away = generate_team_comparison(away_df, team, compare_team)
+
+        if stats_total.empty:
             st.warning("⚠️ Jeden z týmů nemá dostupná data pro zvolený filtr.")
             return
+
+        render_team_comparison_section(
+            team, compare_team,
+            stats_total, stats_home, stats_away
+        )
+        return
 
 
 

--- a/utils/poisson_utils/team_analysis.py
+++ b/utils/poisson_utils/team_analysis.py
@@ -596,49 +596,51 @@ def expected_goals_combined_homeaway_allmatches(
 
 import pandas as pd
 
-def render_team_comparison_section(team1, team2, stats_total_1, stats_home_1, stats_away_1,
-                                     stats_total_2, stats_home_2, stats_away_2):
+TEAM_COMPARISON_ICON_MAP = {
+    "Góly": "⚽",
+    "Obdržené góly": "🥅",
+    "Střely": "📸",
+    "Na branku": "🎯",
+    "Rohy": "🚩",
+    "Fauly": "⚠️",
+    "Žluté": "🟨",
+    "Červené": "🟥",
+    "Ofenzivní efektivita": "⚡",
+    "Defenzivní efektivita": "🛡️",
+    "Přesnost střel": "🎯",
+    "Konverzní míra": "🌟",
+    "Čistá konta %": "🧤",
+    "Over 2.5 %": "📈",
+    "BTTS %": "🎯",
+}
+
+
+def render_team_comparison_section(team1, team2, stats_total, stats_home, stats_away):
     st.markdown(f"## 🆚 Porovnání týmů: {team1} vs {team2}")
 
-    icon_map = {
-        "Góly": "⚽", "Obdržené góly": "🥅", "Střely": "📸",
-        "Na branku": "🎯", "Rohy": "🚩", "Fauly": "⚠️",
-        "Žluté": "🟨", "Červené": "🟥", "Přesnost střel": "🎯",
-        "Konverzní míra": "🌟", "Čistá konta %": "🧤",
-        "Over 2.5 %": "📈", "BTTS %": "🎯"
-    }
-
-    metriky = [
-        "Góly", "Obdržené góly", "Střely", "Na branku", "Rohy", "Fauly",
-        "Žluté", "Červené", "Přesnost střel", "Konverzní míra",
-        "Čistá konta %", "Over 2.5 %", "BTTS %"
-    ]
+    metrics = list(TEAM_COMPARISON_ICON_MAP.keys())
 
     col_celkem, col_doma, col_venku = st.columns(3)
 
+    def _render_column(df, title):
+        st.markdown(title)
+        for met in metrics:
+            icon = TEAM_COMPARISON_ICON_MAP.get(met, "")
+            val1 = df.at[met, team1] if met in df.index else 0
+            val2 = df.at[met, team2] if met in df.index else 0
+            st.markdown(
+                f"{icon} **{val1:.2f}** <span style='color:gray;'>({val2:.2f})</span>",
+                unsafe_allow_html=True,
+            )
+
     with col_celkem:
-        st.markdown("### Celkem")
-        for met in metriky:
-            icon = icon_map.get(met, "")
-            val = stats_total_1.get(met, 0)
-            delta_val = stats_total_2.get(met, 0)
-            st.markdown(f"{icon} **{val:.2f}** <span style='color:gray;'>({delta_val:.2f})</span>", unsafe_allow_html=True)
+        _render_column(stats_total, "### Celkem")
 
     with col_doma:
-        st.markdown("### 🏠 Doma")
-        for met in metriky:
-            icon = icon_map.get(met, "")
-            val = stats_home_1.get(met, 0)
-            delta_val = stats_home_2.get(met, 0)
-            st.markdown(f"{icon} **{val:.2f}** <span style='color:gray;'>({delta_val:.2f})</span>", unsafe_allow_html=True)
+        _render_column(stats_home, "### 🏠 Doma")
 
     with col_venku:
-        st.markdown("### 🚌 Venku")
-        for met in metriky:
-            icon = icon_map.get(met, "")
-            val = stats_away_1.get(met, 0)
-            delta_val = stats_away_2.get(met, 0)
-            st.markdown(f"{icon} **{val:.2f}** <span style='color:gray;'>({delta_val:.2f})</span>", unsafe_allow_html=True)
+        _render_column(stats_away, "### 🚌 Venku")
 
 
 
@@ -683,34 +685,35 @@ def generate_team_comparison(df: pd.DataFrame, team1: str, team2: str) -> pd.Dat
             total_matches += 1
 
         return {
-            "⚽ Góly": goals,
-            "🥅 Obdržené góly": goals_conceded,
-            "📸 Střely": shots,
-            "🎯 Na branku": shots_on_target,
-            "🚩 Rohy": corners,
-            "⚠️ Fauly": fouls,
-            "🟨 Žluté": yellows,
-            "🟥 Červené": reds,
-            "⚡ Ofenzivní efektivita": offensive_eff,
-            "🛡️ Defenzivní efektivita": defensive_eff,
-            "🎯 Přesnost střel": accuracy * 100,
-            "🌟 Konverzní míra": conversion * 100,
-            "🧤 Čistá konta %": (clean_sheets / total_matches) * 100 if total_matches else 0,
-            "📈 Over 2.5 %": (over25 / total_matches) * 100 if total_matches else 0,
-            "🎯 BTTS %": (btts / total_matches) * 100 if total_matches else 0,
+            "Góly": goals,
+            "Obdržené góly": goals_conceded,
+            "Střely": shots,
+            "Na branku": shots_on_target,
+            "Rohy": corners,
+            "Fauly": fouls,
+            "Žluté": yellows,
+            "Červené": reds,
+            "Ofenzivní efektivita": offensive_eff,
+            "Defenzivní efektivita": defensive_eff,
+            "Přesnost střel": accuracy * 100,
+            "Konverzní míra": conversion * 100,
+            "Čistá konta %": (clean_sheets / total_matches) * 100 if total_matches else 0,
+            "Over 2.5 %": (over25 / total_matches) * 100 if total_matches else 0,
+            "BTTS %": (btts / total_matches) * 100 if total_matches else 0,
         }
 
     stats1 = team_stats(df, team1)
     stats2 = team_stats(df, team2)
 
-    metrics = list(stats1.keys())
+    metrics = sorted(set(stats1.keys()) | set(stats2.keys()))
     rows = []
     for m in metrics:
         val1 = stats1.get(m, 0)
         val2 = stats2.get(m, 0)
-        diff = val1 - val2
-        rows.append([m, round(val1, 1), round(val2, 1)])  # odstraněn rozdíl
+        rows.append([m, round(val1, 1), round(val2, 1)])
 
+    if not rows:
+        return pd.DataFrame()
 
     return pd.DataFrame(rows, columns=["Metrika", team1, team2]).set_index("Metrika")
 


### PR DESCRIPTION
## Summary
- Separate icon mapping from team comparison metrics and return plain metric names
- Update team comparison rendering to use the new metric data and icons
- Use generate_team_comparison for total/home/away comparison in team detail view

## Testing
- `pytest -q`
- Manually generated comparison data to verify icon mapping and non-zero metric values

------
https://chatgpt.com/codex/tasks/task_e_68972b139fa88329a41f90f2d4aa54f6