### PR TITLE
refactor: display team comparison table

### DIFF
--- a/utils/poisson_utils/team_analysis.py
+++ b/utils/poisson_utils/team_analysis.py
@@ -639,33 +639,29 @@ def render_team_comparison_section(team1, team2, stats_total, stats_home, stats_
     metrics = list(TEAM_COMPARISON_ICON_MAP.keys())
     col_celkem, col_doma, col_venku = st.columns(3)
 
-    def _render_column(df, title):
-        st.markdown(title)
-        # bezpečné čtení přes .loc, metrika musí být v indexu
+    def _build_table(df: pd.DataFrame) -> pd.DataFrame:
+        rows = []
         for met in metrics:
             if met not in df.index:
                 continue
             icon = TEAM_COMPARISON_ICON_MAP.get(met, "")
-            desc = TEAM_COMPARISON_DESC_MAP.get(met, "")
             try:
                 v1 = float(df.at[met, team1])
                 v2 = float(df.at[met, team2])
             except KeyError:
-                # pokud některý tým v df chybí, přeskoč řádek
                 continue
-            st.markdown(
-                f"<span title='{desc}'>{icon} <strong>{met}</strong></span><br>"
-                f"{team1}: <strong>{v1:.2f}</strong> | "
-                f"{team2}: <span style='color:gray;'>{v2:.2f}</span>",
-                unsafe_allow_html=True,
-            )
+            rows.append({"Metrika": f"{icon} {met}", team1: round(v1, 2), team2: round(v2, 2)})
+        return pd.DataFrame(rows, columns=["Metrika", team1, team2])
 
     with col_celkem:
-        _render_column(stats_total, "### Celkem")
+        st.markdown("### Celkem")
+        st.table(_build_table(stats_total))
     with col_doma:
-        _render_column(stats_home, "### 🏠 Doma")
+        st.markdown("### 🏠 Doma")
+        st.table(_build_table(stats_home))
     with col_venku:
-        _render_column(stats_away, "### 🚌 Venku")
+        st.markdown("### 🚌 Venku")
+        st.table(_build_table(stats_away))
 
 
 


### PR DESCRIPTION
## Summary
- render team comparison metrics via tables instead of iterative markdown

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68974cc6c55883299122e2b922220542