### PR TITLE
Style team comparison columns

### DIFF
--- a/utils/poisson_utils/team_analysis.py
+++ b/utils/poisson_utils/team_analysis.py
@@ -646,22 +646,48 @@ def render_team_comparison_section(team1, team2, stats_total, stats_home, stats_
                 continue
             icon = TEAM_COMPARISON_ICON_MAP.get(met, "")
             try:
-                v1 = float(df.at[met, team1])
-                v2 = float(df.at[met, team2])
+                v1 = float(df.at[met, "team1"])
+                v2 = float(df.at[met, "team2"])
             except KeyError:
                 continue
-            rows.append({"Metrika": f"{icon} {met}", team1: round(v1, 2), team2: round(v2, 2)})
-        return pd.DataFrame(rows, columns=["Metrika", team1, team2])
+            rows.append({
+                "Metrika": f"{icon} {met}",
+                "team1": round(v1, 2),
+                "team2": round(v2, 2),
+            })
+        return pd.DataFrame(rows, columns=["Metrika", "team1", "team2"])
+
+    def _style_and_display(df: pd.DataFrame):
+        legend_html = (
+            f"<span style='background-color:#add8e6;padding:0 8px;border-radius:4px;'>&nbsp;</span> {team1}"
+            f" &nbsp; <span style='background-color:#d3d3d3;padding:0 8px;border-radius:4px;'>&nbsp;</span> {team2}"
+        )
+        st.caption(legend_html, unsafe_allow_html=True)
+        styled = df.style.set_properties(
+            subset=["team1"], **{"background-color": "#add8e6"}
+        ).set_properties(
+            subset=["team2"], **{"background-color": "#d3d3d3"}
+        )
+        st.dataframe(
+            styled,
+            hide_index=True,
+            use_container_width=True,
+            column_config={
+                "Metrika": "Metrika",
+                "team1": st.column_config.NumberColumn(team1),
+                "team2": st.column_config.NumberColumn(team2),
+            },
+        )
 
     with col_celkem:
         st.markdown("### Celkem")
-        st.table(_build_table(stats_total))
+        _style_and_display(_build_table(stats_total))
     with col_doma:
         st.markdown("### 🏠 Doma")
-        st.table(_build_table(stats_home))
+        _style_and_display(_build_table(stats_home))
     with col_venku:
         st.markdown("### 🚌 Venku")
-        st.table(_build_table(stats_away))
+        _style_and_display(_build_table(stats_away))
 
 
 
@@ -737,7 +763,7 @@ def generate_team_comparison(df: pd.DataFrame, team1: str, team2: str) -> pd.Dat
     if not rows:
         return pd.DataFrame()
 
-    return pd.DataFrame(rows, columns=["Metrika", team1, team2]).set_index("Metrika")
+    return pd.DataFrame(rows, columns=["Metrika", "team1", "team2"]).set_index("Metrika")
 
 
 


### PR DESCRIPTION
## Summary
- Rename comparison DataFrame columns to `team1` and `team2`
- Render team comparison tables with column-configured `st.dataframe` and colored columns
- Add caption legend highlighting colors for both teams

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68974dbe117483298a7c42732942235b