### PR TITLE
Remove unused clean sheets import

### DIFF
--- a/utils/utils_warnings.py
+++ b/utils/utils_warnings.py
@@ -5,7 +5,6 @@ from scipy.stats import poisson
 import streamlit as st
 from itertools import product
 
-from utils.statistics import calculate_clean_sheets  # noqa: F401
 from utils.poisson_utils.stats import calculate_points
 
 def load_data(file_path):


### PR DESCRIPTION
## Summary
- drop unused `calculate_clean_sheets` import from `utils_warnings`

## Testing
- `python -m py_compile utils/utils_warnings.py`
- `pytest`
- `flake8 utils/utils_warnings.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68976e7f1b308329ad960a99ab7be447