### PR TITLE
Add tests for season detection and data updating

### DIFF
--- a/tests/test_detect_current_season.py
+++ b/tests/test_detect_current_season.py
@@ -1,0 +1,28 @@
+import sys
+import pathlib
+import pandas as pd
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from utils.poisson_utils.data import detect_current_season
+
+
+def test_detect_current_season_identifies_latest_break():
+    df = pd.DataFrame({
+        "Date": [
+            "30/05/2024",
+            "15/08/2024",
+            "22/08/2024",
+            "29/08/2024",
+        ],
+        "HomeTeam": ["A", "B", "C", "D"],
+        "AwayTeam": ["E", "F", "G", "H"],
+    })
+
+    season_df, season_start = detect_current_season(df, gap_days=30)
+
+    assert season_start == pd.Timestamp("2024-08-15")
+    assert list(season_df["Date"]) == [
+        pd.Timestamp("2024-08-15"),
+        pd.Timestamp("2024-08-22"),
+        pd.Timestamp("2024-08-29"),
+    ]

--- a/tests/test_update_all_leagues.py
+++ b/tests/test_update_all_leagues.py
@@ -1,0 +1,37 @@
+import sys
+import pathlib
+import pandas as pd
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import utils.update_data as update_data
+
+
+def test_update_all_leagues_adds_new_matches(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    existing_path = data_dir / "XX_combined_full_updated.csv"
+    pd.DataFrame({
+        "Date": ["01/08/2024"],
+        "HomeTeam": ["A"],
+        "AwayTeam": ["B"],
+    }).to_csv(existing_path, index=False)
+
+    monkeypatch.setattr(update_data, "LEAGUES", {"XX": "http://example.com/xx.csv"})
+
+    new_csv = "Date,HomeTeam,AwayTeam\n01/08/2024,A,B\n08/08/2024,C,D\n"
+
+    class DummyResp:
+        def __init__(self, text):
+            self.status_code = 200
+            self.text = text
+
+    monkeypatch.setattr(update_data.requests, "get", lambda url: DummyResp(new_csv))
+    monkeypatch.chdir(tmp_path)
+
+    messages = update_data.update_all_leagues()
+
+    assert messages == ["✅ XX: Přidáno 1 nových zápasů."]
+
+    updated = pd.read_csv(existing_path)
+    assert len(updated) == 2
+    assert "08/08/2024" in updated["Date"].values


### PR DESCRIPTION
## Summary
- add test verifying `detect_current_season` identifies the latest season break
- add test ensuring `update_all_leagues` appends new matches and reports updates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689770d628748329a80b0f55049df843