### PR TITLE
Use Streamlit cache for multi-match league data and ELO

### DIFF
--- a/sections/multi_prediction_section.py
+++ b/sections/multi_prediction_section.py
@@ -10,6 +10,16 @@ from utils.poisson_utils import (
 )
 from utils.frontend_utils import validate_dataset
 
+
+@st.cache_data
+def get_league_data_and_elo(league_file: str):
+    """Load league dataset and compute its ELO ratings with caching."""
+    df_league = load_data(league_file)
+    validate_dataset(df_league)
+    elo_dict = calculate_elo_ratings(df_league)
+    return df_league, elo_dict
+
+
 def render_multi_match_predictions(session_state, home_team, away_team, league_name, league_file, league_files):
     st.title("📋 Hromadné predikce zápasů")
 
@@ -30,29 +40,13 @@ def render_multi_match_predictions(session_state, home_team, away_team, league_n
     if session_state.match_list:
         export_data = []
 
-        # Pre-load datasets and ELO ratings for each league to avoid
-        # recalculating them for every match.  Dictionaries are keyed by the
-        # league's file identifier so matches from the same league reuse the
-        # cached values.
-        league_data_cache = {}
-        elo_cache = {}
-
-        for match in session_state.match_list:
-            league_code = match["league_file"]
-            if league_code not in league_data_cache:
-                df_league = load_data(league_code)
-                validate_dataset(df_league)
-                league_data_cache[league_code] = df_league
-                elo_cache[league_code] = calculate_elo_ratings(df_league)
-
         for idx, match in enumerate(session_state.match_list):
             with st.container():
                 st.markdown("---")
                 st.subheader(f"🔮 {match['home_team']} vs {match['away_team']} {match['league_name']}")
 
                 try:
-                    df_match = league_data_cache[match["league_file"]]
-                    elo_dict = elo_cache[match["league_file"]]
+                    df_match, elo_dict = get_league_data_and_elo(match["league_file"])
                     home_exp, away_exp = expected_goals_weighted_by_elo(
                         df_match, match["home_team"], match["away_team"], elo_dict
                     )

--- a/tests/test_multi_prediction_cache.py
+++ b/tests/test_multi_prediction_cache.py
@@ -1,7 +1,8 @@
 import sections.multi_prediction_section as mp
 from unittest.mock import patch
 
-def test_preload_league_data_and_elo_reuses_results():
+
+def test_get_league_data_and_elo_uses_cache():
     league_file = "data/E0_combined_full_updated.csv"
     df = mp.load_data(league_file)
     match_list = [
@@ -19,28 +20,21 @@ def test_preload_league_data_and_elo_reuses_results():
         },
     ]
 
+    mp.get_league_data_and_elo.clear()
+
     with patch("sections.multi_prediction_section.load_data", wraps=mp.load_data) as mock_load, \
          patch("sections.multi_prediction_section.calculate_elo_ratings", wraps=mp.calculate_elo_ratings) as mock_elo:
-        league_data_cache = {}
-        elo_cache = {}
-        for match in match_list:
-            code = match["league_file"]
-            if code not in league_data_cache:
-                df_league = mp.load_data(code)
-                mp.validate_dataset(df_league)
-                league_data_cache[code] = df_league
-                elo_cache[code] = mp.calculate_elo_ratings(df_league)
-        assert mock_load.call_count == 1
-        assert mock_elo.call_count == 1
 
         cached_results = []
         for match in match_list:
-            df_match = league_data_cache[match["league_file"]]
-            elo_dict = elo_cache[match["league_file"]]
+            df_match, elo_dict = mp.get_league_data_and_elo(match["league_file"])
             home_exp, away_exp = mp.expected_goals_weighted_by_elo(
                 df_match, match["home_team"], match["away_team"], elo_dict
             )
             cached_results.append((home_exp, away_exp))
+
+        assert mock_load.call_count == 1
+        assert mock_elo.call_count == 1
 
     direct_results = []
     for match in match_list:


### PR DESCRIPTION
## Summary
- Add `get_league_data_and_elo` helper using `st.cache_data` to load league data and compute ELO ratings once per league
- Simplify `render_multi_match_predictions` to rely on cached helper instead of local dictionaries
- Update tests to validate cached helper reuses loaded data and ratings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68978940efe48329be5876c654220898