### PR TITLE
Fix KeyError in team comparison styling

### DIFF
--- a/utils/poisson_utils/team_analysis.py
+++ b/utils/poisson_utils/team_analysis.py
@@ -734,7 +734,7 @@ def render_team_comparison_section(team1, team2, stats_total, stats_home, stats_
             df.style
             .set_properties(subset=["team1"], **{"background-color": "#add8e6"})
             .set_properties(subset=["team2"], **{"background-color": "#d3d3d3"})
-            .apply(_highlight, axis=1, subset=["team1", "team2", "Δ"])
+            .apply(_highlight, axis=1)
         )
         st.dataframe(
             styled,


### PR DESCRIPTION
## Summary
- ensure Metrika column is included when applying comparison row highlight styles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897941880008329afa747ace58dede5