### PR TITLE
Round displayed stats to one decimal

### DIFF
--- a/sections/match_prediction_section.py
+++ b/sections/match_prediction_section.py
@@ -88,7 +88,7 @@ def compute_match_inputs(
 
     gii_home = gii_dict.get(home_team)
     gii_away = gii_dict.get(away_team)
-    expected_gii = round(((gii_home or 0) + (gii_away or 0)) / 2, 2)
+    expected_gii = round(((gii_home or 0) + (gii_away or 0)) / 2, 1)
     expected_tempo = expected_match_tempo(
         df,
         home_team,
@@ -155,9 +155,9 @@ def display_metrics(
     """Display key statistical metrics and outcome probabilities."""
     st.markdown("## 📊 Klíčové metriky")
     cols = st.columns(4)
-    cols[0].metric("xG sezóna", f"{xg_home['xG_home']} vs {xg_away['xG_away']}")
-    cols[1].metric("Oček. body (xP)", f"{xpoints['Home xP']} vs {xpoints['Away xP']}")
-    cols[2].metric("BTTS / Over 2.5", f"{btts['BTTS Yes']}% / {over_under['Over 2.5']}%")
+    cols[0].metric("xG sezóna", f"{xg_home['xG_home']:.1f} vs {xg_away['xG_away']:.1f}")
+    cols[1].metric("Oček. body (xP)", f"{xpoints['Home xP']:.1f} vs {xpoints['Away xP']:.1f}")
+    cols[2].metric("BTTS / Over 2.5", f"{btts['BTTS Yes']:.1f}% / {over_under['Over 2.5']:.1f}%")
     cols[2].caption(
         f"Kurzy: {1 / (btts['BTTS Yes'] / 100):.2f} / {1 / (over_under['Over 2.5'] / 100):.2f}"
     )
@@ -166,20 +166,20 @@ def display_metrics(
     cols2 = st.columns(4)
     cols2[0].metric(
         "🏠 Výhra domácích",
-        f"{outcomes['Home Win']}%",
+        f"{outcomes['Home Win']:.1f}%",
         f"{1 / (outcomes['Home Win'] / 100):.2f}",
     )
     cols2[1].metric(
         "🤝 Remíza",
-        f"{outcomes['Draw']}%",
+        f"{outcomes['Draw']:.1f}%",
         f"{1 / (outcomes['Draw'] / 100):.2f}",
     )
     cols2[2].metric(
         "🚶‍♂️ Výhra hostů",
-        f"{outcomes['Away Win']}%",
+        f"{outcomes['Away Win']:.1f}%",
         f"{1 / (outcomes['Away Win'] / 100):.2f}",
     )
-    cols2[3].metric("🔒 Confidence", f"{confidence_index} %")
+    cols2[3].metric("🔒 Confidence", f"{confidence_index:.1f} %")
 
 
 

--- a/sections/multi_prediction_section.py
+++ b/sections/multi_prediction_section.py
@@ -58,18 +58,18 @@ def render_multi_match_predictions(session_state, home_team, away_team, league_n
 
                     cols = st.columns(3)
                     cols[0].metric("⚽ Očekávané góly", f"{home_exp:.1f} - {away_exp:.1f}")
-                    cols[1].metric("🔵 BTTS %", f"{btts['BTTS Yes']}%")
-                    cols[2].metric("📈 Over 2.5 %", f"{over_under['Over 2.5']}%")
+                    cols[1].metric("🔵 BTTS %", f"{btts['BTTS Yes']:.1f}%")
+                    cols[2].metric("📈 Over 2.5 %", f"{over_under['Over 2.5']:.1f}%")
                     # Výpočet confidence score – rozdíl mezi nejvyšší a druhou nejvyšší výstupní pravděpodobností
                     sorted_probs = sorted(outcomes.values(), reverse=True)
                     confidence_index = round(sorted_probs[0] - sorted_probs[1], 1) if len(sorted_probs) >= 2 else 0.0
 
                     st.markdown("#### 🧠 Pravděpodobnosti výsledků")
                     result_cols = st.columns(4)
-                    result_cols[0].metric("🏠 Výhra domácích", f"{outcomes['Home Win']}%", f"{prob_to_odds(outcomes['Home Win'])}")
-                    result_cols[1].metric("🤝 Remíza", f"{outcomes['Draw']}%", f"{prob_to_odds(outcomes['Draw'])}")
-                    result_cols[2].metric("🚶‍♂️ Výhra hostů", f"{outcomes['Away Win']}%", f"{prob_to_odds(outcomes['Away Win'])}")
-                    result_cols[3].metric("🔒 Confidence", f"{confidence_index} %")
+                    result_cols[0].metric("🏠 Výhra domácích", f"{outcomes['Home Win']:.1f}%", f"{prob_to_odds(outcomes['Home Win'])}")
+                    result_cols[1].metric("🤝 Remíza", f"{outcomes['Draw']:.1f}%", f"{prob_to_odds(outcomes['Draw'])}")
+                    result_cols[2].metric("🚶‍♂️ Výhra hostů", f"{outcomes['Away Win']:.1f}%", f"{prob_to_odds(outcomes['Away Win'])}")
+                    result_cols[3].metric("🔒 Confidence", f"{confidence_index:.1f} %")
                     
                     top_scores = get_top_scorelines(matrix, top_n=1)
                     if top_scores:
@@ -84,13 +84,13 @@ def render_multi_match_predictions(session_state, home_team, away_team, league_n
                         "League": match["league_name"],
                         "Home": match["home_team"],
                         "Away": match["away_team"],
-                        "Home ExpG": round(home_exp, 2),
-                        "Away ExpG": round(away_exp, 2),
-                        "BTTS %": btts['BTTS Yes'],
-                        "Over 2.5 %": over_under['Over 2.5'],
-                        "Home Win %": outcomes["Home Win"],
-                        "Draw %": outcomes["Draw"],
-                        "Away Win %": outcomes["Away Win"],
+                        "Home ExpG": round(home_exp, 1),
+                        "Away ExpG": round(away_exp, 1),
+                        "BTTS %": round(btts['BTTS Yes'], 1),
+                        "Over 2.5 %": round(over_under['Over 2.5'], 1),
+                        "Home Win %": round(outcomes["Home Win"], 1),
+                        "Draw %": round(outcomes["Draw"], 1),
+                        "Away Win %": round(outcomes["Away Win"], 1),
                         "Top Score": f"{top_scores[0][0][0]}:{top_scores[0][0][1]}",
                         "Confidence %": confidence_index
                     })

--- a/sections/overview_section.py
+++ b/sections/overview_section.py
@@ -42,8 +42,8 @@ def render_league_overview(season_df, league_name, gii_dict, elo_dict):
     for team in team_stats.index:
         score_list, avg_goals_per_match, score_variance = compute_score_stats(season_df, team)
         trends.append(compute_form_trend(score_list))
-        avg_goals_all.append(round(avg_goals_per_match, 2))
-        score_var.append(round(score_variance, 2))
+        avg_goals_all.append(round(avg_goals_per_match, 1))
+        score_var.append(round(score_variance, 1))
 
     summary_table = pd.DataFrame({
         "Tým": team_stats.index,
@@ -53,11 +53,11 @@ def render_league_overview(season_df, league_name, gii_dict, elo_dict):
         "Trend formy": trends,
         "Góly celkem": avg_goals_all,
         "Rozptyl skóre": score_var,
-        "Vstřelené Góly": team_stats["Góly"].round(2),
+        "Vstřelené Góly": team_stats["Góly"].round(1),
         "Střely": team_stats["Střely"].round(1),
         "Na branku": team_stats["Na branku"].round(1),
         "Rohy": team_stats["Rohy"].round(1),
-        "Obdržené góly": team_stats["Obdržené góly"].round(2),
+        "Obdržené góly": team_stats["Obdržené góly"].round(1),
         "Čistá konta %": team_stats.index.map(lambda t: f"{calculate_clean_sheets(season_df, t)}%"),
         "Over 2.5 %": team_stats.index.map(over25).astype(str) + "%",
         "BTTS %": team_stats.index.map(btts).astype(str) + "%",

--- a/sections/team_detail_section.py
+++ b/sections/team_detail_section.py
@@ -150,7 +150,7 @@ def render_team_detail(
     def compare_stat(name, team_value, league_avg):
         league_value = league_avg.get(name, 0)
         diff = team_value - league_value
-        return f" *(liga: {league_value:.2f}, Δ {diff:+.2f})*"
+        return f" *(liga: {league_value:.1f}, Δ {diff:+.1f})*"
 
     advanced_stats = calculate_advanced_team_metrics(season_df)
     league_avg_advanced = advanced_stats.mean()
@@ -253,7 +253,7 @@ def render_team_detail(
         inverse = metric_name in inverse_metrics
         
         color = "red" if (diff > 0 and inverse) or (diff < 0 and not inverse) else "green"
-        return f"<span style='color:{color}'>{arrow} {diff:+.2f}</span>"
+        return f"<span style='color:{color}'>{arrow} {diff:+.1f}</span>"
 
     # Funkce pro výpis jednoho sloupce
     # def display_metrics_block(col, title, data, adv_data, extra):
@@ -283,9 +283,9 @@ def render_team_detail(
 
             def format_metric(label, value, delta_str):
                 if show_labels:
-                    return f"**{label}:** {value:.2f} {delta_str}"
+                    return f"**{label}:** {value:.1f} {delta_str}"
                 else:
-                    return f"{value:.2f} {delta_str}"
+                    return f"{value:.1f} {delta_str}"
 
             st.markdown(format_metric("⚽ Góly", data['Góly'], colored_delta(data['Góly'], league_avg['Góly'], 'Góly')), unsafe_allow_html=True)
             st.markdown(format_metric("🥅 Obdržené góly", data['Obdržené góly'], colored_delta(data['Obdržené góly'], league_avg['Obdržené góly'], 'Obdržené góly')), unsafe_allow_html=True)

--- a/utils/poisson_utils/match_style.py
+++ b/utils/poisson_utils/match_style.py
@@ -738,12 +738,12 @@ def analyze_team_profile(
         profile_tags.append("❗ Zranitelná defenziva (gól z každé 8. střely)")
 
     if yellow_per_foul > 0.25:
-        profile_tags.append(f"🟡 Fauly často trestané žlutou ({yellow_per_foul:.2f})")
+        profile_tags.append(f"🟡 Fauly často trestané žlutou ({yellow_per_foul:.1f})")
     else:
-        profile_tags.append(f"🟢 Disciplína v normě ({yellow_per_foul:.2f})")
+        profile_tags.append(f"🟢 Disciplína v normě ({yellow_per_foul:.1f})")
 
     if red_per_foul > 0.05:
-        profile_tags.append(f"🔴 Riziko červených ({red_per_foul:.2f} na faul)")
+        profile_tags.append(f"🔴 Riziko červených ({red_per_foul:.1f} na faul)")
 
     return {
         "forma": "".join(results[:5]),

--- a/utils/poisson_utils/prediction.py
+++ b/utils/poisson_utils/prediction.py
@@ -113,7 +113,7 @@ def expected_goals_vs_similar_elo_weighted(df, home_team, away_team, elo_dict, e
 
     logger.info("📘 ELO-based: Home/Away only")
     logger.info(
-        "  HomeExp: %.2f, AwayExp: %.2f → Over 2.5: %s%%",
+        "  HomeExp: %.1f, AwayExp: %.1f → Over 2.5: %s%%",
         home_exp_home,
         away_exp_away,
         poisson_over25_probability(home_exp_home, away_exp_away),
@@ -121,18 +121,18 @@ def expected_goals_vs_similar_elo_weighted(df, home_team, away_team, elo_dict, e
 
     logger.info("📘 ELO-based: All relevant matches")
     logger.info(
-        "  HomeExp: %.2f, AwayExp: %.2f → Over 2.5: %s%%",
+        "  HomeExp: %.1f, AwayExp: %.1f → Over 2.5: %s%%",
         home_exp_all,
         away_exp_all,
         poisson_over25_probability(home_exp_all, away_exp_all),
     )
 
-    combined_home = round((home_exp_home + home_exp_all) / 2, 2)
-    combined_away = round((away_exp_away + away_exp_all) / 2, 2)
+    combined_home = round((home_exp_home + home_exp_all) / 2, 1)
+    combined_away = round((away_exp_away + away_exp_all) / 2, 1)
 
     logger.info("🎯 ELO-based kombinace")
     logger.info(
-        "  FinalExp: %.2f - %.2f → Over 2.5: %s%%",
+        "  FinalExp: %.1f - %.1f → Over 2.5: %s%%",
         combined_home,
         combined_away,
         poisson_over25_probability(combined_home, combined_away),

--- a/utils/poisson_utils/team_analysis.py
+++ b/utils/poisson_utils/team_analysis.py
@@ -744,7 +744,7 @@ def render_team_comparison_section(team1, team2, stats_total, stats_home, stats_
                 "Metrika": "Metrika",
                 "team1": st.column_config.NumberColumn(team1),
                 "team2": st.column_config.NumberColumn(team2),
-                "Δ": st.column_config.NumberColumn("Δ", format="%.2f"),
+                "Δ": st.column_config.NumberColumn("Δ", format="%.1f"),
                 "Lepší": "Lepší",
             },
         )


### PR DESCRIPTION
## Summary
- Round expected intensity and prediction metrics to one decimal for cleaner Streamlit displays
- Limit league overview and team detail tables to single decimal precision
- Format disciplinary tags and ELO-based expectations with tenths precision

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68979b7743a4832987e55eb1fe52ad74