### PR TITLE
refactor: inline team comparison rendering

### DIFF
--- a/utils/poisson_utils/team_analysis.py
+++ b/utils/poisson_utils/team_analysis.py
@@ -654,7 +654,9 @@ def render_team_comparison_section(team1: str, team2: str, stats_total: pd.DataF
             v1 = float(df.at[met, "team1"])
             v2 = float(df.at[met, "team2"])
             higher_better = TEAM_COMPARISON_HIGHER_IS_BETTER.get(met, True)
-            better = team1 if (v1 > v2) == higher_better else team2 if v1 != v2 else "="
+            better = "="
+            if v1 != v2:
+                better = team1 if (v1 > v2) == higher_better else team2
             rows.append({
                 "Metrika": f"{icon} {met}",
                 team1: round(v1, 2),


### PR DESCRIPTION
## Summary
- inline team comparison table rendering logic
- build tables using available metrics and show message when no data is present
- rename columns to team names for clearer display

## Testing
- `pytest`
- `streamlit run app.py`


------
https://chatgpt.com/codex/tasks/task_e_6897a6f948648329b7f7751fd878322a