### PR TITLE
Use full team list for comparison

### DIFF
--- a/sections/team_detail_section.py
+++ b/sections/team_detail_section.py
@@ -71,9 +71,12 @@ def render_team_detail(
         ["Vše", "Silní", "Průměrní", "Slabí"]
     )
 
+    teams_home = original_df["HomeTeam"].unique().tolist()
+    teams_away = original_df["AwayTeam"].unique().tolist()
+    compare_options = sorted(set(teams_home + teams_away) - {team})
     compare_team = st.sidebar.selectbox(
         "🔄 Porovnat s jiným týmem:",
-        ["Žádný"] + sorted(filtered_df['HomeTeam'].unique().tolist())
+        ["Žádný"] + compare_options
     )
 
     def _apply_difficulty_filter(data: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- ensure compare-team selectbox uses every team from the season dataset, excluding the selected team
- keep comparisons working with time-based filters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898456accc48329bc5ec15110e0c391