### PR TITLE
feat: support multiple over-under thresholds

### DIFF
--- a/sections/match_prediction_section.py
+++ b/sections/match_prediction_section.py
@@ -43,7 +43,10 @@ def get_cached_match_inputs(df_hash,df, home_team, away_team, elo_dict):
     #home_exp, away_exp = expected_goals_weighted_by_elo(df, home_team, away_team, elo_dict)
     matrix = poisson_prediction(home_exp, away_exp)
     outcomes = match_outcomes_prob(matrix)
-    over_under = over_under_prob(matrix)
+    # Compute Over/Under probabilities for multiple goal lines
+    over_under = {}
+    for thr in (1.5, 2.5, 3.5):
+        over_under.update(over_under_prob(matrix, thr))
     btts = btts_prob(matrix)
     xpoints = calculate_expected_points(outcomes)
 
@@ -157,9 +160,16 @@ def display_metrics(
     cols = st.columns(4)
     cols[0].metric("xG sezóna", f"{xg_home['xG_home']:.1f} vs {xg_away['xG_away']:.1f}")
     cols[1].metric("Oček. body (xP)", f"{xpoints['Home xP']:.1f} vs {xpoints['Away xP']:.1f}")
-    cols[2].metric("BTTS / Over 2.5", f"{btts['BTTS Yes']:.1f}% / {over_under['Over 2.5']:.1f}%")
+    cols[2].metric("BTTS", f"{btts['BTTS Yes']:.1f}%")
     cols[2].caption(
-        f"Kurzy: {1 / (btts['BTTS Yes'] / 100):.2f} / {1 / (over_under['Over 2.5'] / 100):.2f}"
+        f"Kurzy: {1 / (btts['BTTS Yes'] / 100):.2f}"
+    )
+    cols[3].metric(
+        "Over 1.5 / 2.5 / 3.5",
+        f"{over_under['Over 1.5']:.1f}% / {over_under['Over 2.5']:.1f}% / {over_under['Over 3.5']:.1f}%",
+    )
+    cols[3].caption(
+        f"Kurzy: {1 / (over_under['Over 1.5'] / 100):.2f} / {1 / (over_under['Over 2.5'] / 100):.2f} / {1 / (over_under['Over 3.5'] / 100):.2f}"
     )
 
     st.markdown("## 🧠 Pravděpodobnosti výsledků")

--- a/sections/multi_prediction_section.py
+++ b/sections/multi_prediction_section.py
@@ -52,7 +52,7 @@ def render_multi_match_predictions(session_state, home_team, away_team, league_n
                     )
                     matrix = poisson_prediction(home_exp, away_exp)
                     outcomes = match_outcomes_prob(matrix)
-                    over_under = over_under_prob(matrix)
+                    over_under = over_under_prob(matrix, 2.5)
                     btts = btts_prob(matrix)
                     xpoints = calculate_expected_points(outcomes)
 

--- a/tests/test_over_under_prob.py
+++ b/tests/test_over_under_prob.py
@@ -1,0 +1,12 @@
+import math
+
+from utils.poisson_utils import poisson_prediction_matrix, over_under_prob
+
+
+def test_over_under_probabilities_sum_to_100():
+    matrix = poisson_prediction_matrix(1.3, 0.9)
+    for threshold in (1.5, 2.5, 3.5):
+        probs = over_under_prob(matrix, threshold)
+        total = sum(probs.values())
+        assert math.isclose(total, 100.0, abs_tol=0.1)
+


### PR DESCRIPTION
## Summary
- generalize `over_under_prob` to handle any goal line
- show probabilities for 1.5, 2.5 and 3.5 lines in match predictions
- test that over/under probabilities add up to 100%

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68986eedb96c8329aa6c1e5e3ba423d9