### PR TITLE
Add strength of schedule metric and league table enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Komplexní aplikace pro odhad výsledků fotbalových zápasů pomocí **Poisson
 - Hromadná predikce více zápasů s cachováním výsledků
 - Detailní profil týmu včetně ELO ratingu, xG a GII
 - Přehled ligy s tabulkou a základními statistikami
+- Strength of Schedule (SOS) s průměrnou kvalitou soupeřů podle ELO či xG
 - Aktualizace datasetů skriptem nebo API
 - Jednotkové testy pokrývající klíčové funkce
 

--- a/utils/poisson_utils/__init__.py
+++ b/utils/poisson_utils/__init__.py
@@ -53,6 +53,7 @@ from .team_analysis import (
     calculate_conceded_goals,
     calculate_recent_team_form,
     calculate_expected_and_actual_points,
+    calculate_strength_of_schedule,
     analyze_opponent_strength,
     get_head_to_head_stats,
     merged_home_away_opponent_form,


### PR DESCRIPTION
## Summary
- compute average opponent strength via ELO or xG
- show strength of schedule in league overview with sorting and highlights
- document SOS metric in the README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68987b5413e88329a130aaf83fda26c1