### PR TITLE
Add Poisson corner prediction utilities

### DIFF
--- a/sections/team_detail_section.py
+++ b/sections/team_detail_section.py
@@ -10,7 +10,7 @@ from utils.poisson_utils import (
     intensity_score_to_emoji, compute_score_stats, compute_form_trend,
     merged_home_away_opponent_form, classify_team_strength, calculate_advanced_team_metrics,
     calculate_team_extra_stats, get_team_record, analyze_team_profile, generate_team_comparison,
-    render_team_comparison_section
+    render_team_comparison_section, poisson_corner_matrix, corner_over_under_prob
 )
 from utils.statistics import calculate_clean_sheets
 
@@ -242,7 +242,23 @@ def render_team_detail(
     extra_home = calculate_team_extra_stats(home, team)
     extra_away = calculate_team_extra_stats(away, team)
 
-    
+    team_corners_for = metrics_all["Rohy"]
+    corners_against = pd.concat([
+        season_df[season_df['HomeTeam'] == team]['AC'],
+        season_df[season_df['AwayTeam'] == team]['HC']
+    ]).mean()
+    corner_line = st.sidebar.slider("Rohová hranice", 5.5, 15.5, 9.5, 0.5)
+    corner_matrix = poisson_corner_matrix(team_corners_for, corners_against)
+    corner_probs = corner_over_under_prob(corner_matrix, corner_line)
+
+    st.markdown("### 🛎️ Rohy")
+    corn_cols = st.columns(2)
+    corn_cols[0].metric("Průměrné rohy", f"{team_corners_for:.1f} vs {corners_against:.1f}")
+    over_key = f"Over {corner_line}"
+    corn_cols[1].metric(over_key, f"{corner_probs[over_key]:.1f}%")
+    corn_cols[1].caption(f"Under: {corner_probs[f'Under {corner_line}']:.1f}%")
+
+
     st.markdown("### 📊 Průměrné statistiky – Celkem / Doma / Venku")
     col_all, col_home, col_away = st.columns(3)
 

--- a/tests/test_corner_utils.py
+++ b/tests/test_corner_utils.py
@@ -1,0 +1,27 @@
+import math
+import pandas as pd
+
+from utils.poisson_utils import expected_corners, poisson_corner_matrix, corner_over_under_prob
+
+
+def _sample_df():
+    data = [
+        {"Date": "2023-08-01", "HomeTeam": "A", "AwayTeam": "B", "HC": 5, "AC": 3},
+        {"Date": "2023-08-08", "HomeTeam": "A", "AwayTeam": "C", "HC": 7, "AC": 4},
+        {"Date": "2023-08-15", "HomeTeam": "B", "AwayTeam": "A", "HC": 6, "AC": 2},
+        {"Date": "2023-08-22", "HomeTeam": "C", "AwayTeam": "A", "HC": 8, "AC": 5},
+    ]
+    return pd.DataFrame(data)
+
+
+def test_expected_corners():
+    df = _sample_df()
+    home, away = expected_corners(df, "A", "B")
+    assert math.isclose(home, 5.5, rel_tol=1e-4)
+    assert math.isclose(away, 3.25, rel_tol=1e-4)
+
+
+def test_corner_over_under_probabilities_sum_to_100():
+    matrix = poisson_corner_matrix(5.5, 3.25)
+    probs = corner_over_under_prob(matrix, 8.5)
+    assert math.isclose(sum(probs.values()), 100.0, abs_tol=0.1)

--- a/utils/poisson_utils/__init__.py
+++ b/utils/poisson_utils/__init__.py
@@ -84,3 +84,9 @@ from .match_style import (
     get_team_record,
     analyze_team_profile,
 )
+
+from .corners import (
+    expected_corners,
+    poisson_corner_matrix,
+    corner_over_under_prob,
+)

--- a/utils/poisson_utils/corners.py
+++ b/utils/poisson_utils/corners.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pandas as pd
+from scipy.stats import poisson
+from .data import prepare_df
+
+
+def expected_corners(df: pd.DataFrame, home_team: str, away_team: str) -> tuple:
+    """Compute expected corner counts for home and away teams.
+
+    The expectation is a simple average of the team's own corner production and
+    the opponent's corners conceded in the corresponding venue (home/away).
+    If any component is missing, it is ignored in the average and defaulted to 0.
+    """
+    df = prepare_df(df)
+
+    home_for = df[df['HomeTeam'] == home_team]['HC'].mean()
+    home_against = df[df['HomeTeam'] == home_team]['AC'].mean()
+    away_for = df[df['AwayTeam'] == away_team]['AC'].mean()
+    away_against = df[df['AwayTeam'] == away_team]['HC'].mean()
+
+    home_vals = [v for v in [home_for, away_against] if not pd.isna(v)]
+    away_vals = [v for v in [away_for, home_against] if not pd.isna(v)]
+
+    home_exp = np.mean(home_vals) if home_vals else 0.0
+    away_exp = np.mean(away_vals) if away_vals else 0.0
+
+    return round(home_exp, 2), round(away_exp, 2)
+
+
+def poisson_corner_matrix(home_exp: float, away_exp: float, max_corners: int = 20) -> np.ndarray:
+    """Return Poisson probability matrix for corner counts up to ``max_corners``."""
+    home_probs = [poisson.pmf(i, home_exp) for i in range(max_corners + 1)]
+    away_probs = [poisson.pmf(i, away_exp) for i in range(max_corners + 1)]
+    return np.outer(home_probs, away_probs)
+
+
+def corner_over_under_prob(matrix: np.ndarray, threshold: float) -> dict:
+    """Compute over/under probabilities for total corners given a matrix."""
+    size = matrix.shape[0]
+    over = 0.0
+    for i in range(size):
+        for j in range(size):
+            if i + j > threshold:
+                over += matrix[i, j]
+    over_pct = round(over * 100, 2)
+    under_pct = round(100 - over_pct, 2)
+    return {f"Over {threshold}": over_pct, f"Under {threshold}": under_pct}


### PR DESCRIPTION
## Summary
- add `corners.py` utilities for expected corners and Poisson over/under probabilities
- integrate corner stats and sliders into match and team detail sections
- cover corner logic with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68987dbfe70883298139ecbe14f4afb2