### PR TITLE
Add ELO history and team chart

### DIFF
--- a/sections/team_detail_section.py
+++ b/sections/team_detail_section.py
@@ -3,7 +3,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 from typing import Dict
 from utils.poisson_utils import (
-    calculate_elo_ratings, calculate_form_emojis, calculate_expected_and_actual_points,
+    calculate_elo_ratings, elo_history, calculate_form_emojis, calculate_expected_and_actual_points,
     aggregate_team_stats, calculate_team_pseudo_xg, add_btts_column,
     calculate_conceded_goals, calculate_recent_team_form,
     calculate_elo_changes, calculate_team_styles,
@@ -166,6 +166,17 @@ def render_team_detail(
     # stats['Žluté'] = card_stats['yellow']
     # stats['Červené'] = card_stats['red']
     elo_dict = calculate_elo_ratings(season_df)
+
+    # 📈 ELO rating progression
+    elo_prog = elo_history(season_df, team)
+    if not elo_prog.empty:
+        fig, ax = plt.subplots()
+        ax.plot(elo_prog["Date"], elo_prog["ELO"], marker="o")
+        ax.set_title("Vývoj ELO ratingu")
+        ax.set_xlabel("Datum")
+        ax.set_ylabel("ELO")
+        plt.xticks(rotation=45)
+        st.pyplot(fig)
 
     # ✅ Kontrola rozsahu dat a počtu zápasů
     st.caption(f"Počet zápasů v aktuálním datasetu: {len(season_df)}")

--- a/tests/test_elo_history.py
+++ b/tests/test_elo_history.py
@@ -1,0 +1,43 @@
+import sys
+import pathlib
+import pandas as pd
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from utils.poisson_utils.elo import elo_history
+
+
+def test_elo_history_updates_per_match():
+    df = pd.DataFrame({
+        'Date': pd.to_datetime(['2024-01-01', '2024-01-08', '2024-01-15']),
+        'HomeTeam': ['A', 'B', 'A'],
+        'AwayTeam': ['B', 'A', 'C'],
+        'FTHG': [1, 2, 0],
+        'FTAG': [0, 1, 1],
+    })
+
+    history = elo_history(df, 'A')
+    assert len(history) == 3
+    assert history['Date'].tolist() == sorted(history['Date'].tolist())
+
+    # manual incremental calculation
+    df_sorted = df.sort_values('Date')
+    teams = pd.concat([df_sorted['HomeTeam'], df_sorted['AwayTeam']]).unique()
+    elo = {t: 1500 for t in teams}
+    expected = []
+    for _, row in df_sorted.iterrows():
+        home, away = row['HomeTeam'], row['AwayTeam']
+        hg, ag = row['FTHG'], row['FTAG']
+        exp_home = 1 / (1 + 10 ** ((elo[away] - elo[home]) / 400))
+        exp_away = 1 / (1 + 10 ** ((elo[home] - elo[away]) / 400))
+        if hg > ag:
+            res_home, res_away = 1, 0
+        elif hg < ag:
+            res_home, res_away = 0, 1
+        else:
+            res_home = res_away = 0.5
+        elo[home] += 20 * (res_home - exp_home)
+        elo[away] += 20 * (res_away - exp_away)
+        if home == 'A' or away == 'A':
+            expected.append(elo['A'])
+
+    assert history['ELO'].tolist() == expected

--- a/utils/poisson_utils/__init__.py
+++ b/utils/poisson_utils/__init__.py
@@ -27,6 +27,7 @@ from .prediction import (
 
 from .elo import (
     calculate_elo_ratings,
+    elo_history,
     calculate_elo_changes,
     detect_risk_factors,
     detect_positive_factors,


### PR DESCRIPTION
## Summary
- add `elo_history` to track team ratings chronologically
- display ELO progression chart in team detail view
- cover new ELO history logic with unit test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68987fe7ee208329bac6f834bb865230