### PR TITLE
Avoid double data preparation in season detection

### DIFF
--- a/app.py
+++ b/app.py
@@ -98,7 +98,9 @@ def load_and_prepare(file_path: str):
     league_code = file_path.split("/")[-1].split("_")[0]
     start_month = LEAGUE_START_MONTH.get(league_code, 8)
 
-    season_df, _ = detect_current_season(df, start_month=start_month)
+    season_df, _ = detect_current_season(
+        df, start_month=start_month, prepared=True
+    )
     team_strengths, _, _ = calculate_team_strengths(df)  # zachováno kvůli side efektům, pokud nějaké
     season_df = calculate_gii_zscore(season_df)
 

--- a/tests/test_detect_current_season.py
+++ b/tests/test_detect_current_season.py
@@ -3,7 +3,7 @@ import pathlib
 import pandas as pd
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
-from utils.poisson_utils.data import detect_current_season
+from utils.poisson_utils.data import detect_current_season, prepare_df
 
 
 def test_detect_current_season_identifies_latest_break():
@@ -19,6 +19,33 @@ def test_detect_current_season_identifies_latest_break():
     })
 
     season_df, season_start = detect_current_season(df, gap_days=30)
+
+    assert season_start == pd.Timestamp("2024-08-15")
+    assert list(season_df["Date"]) == [
+        pd.Timestamp("2024-08-15"),
+        pd.Timestamp("2024-08-22"),
+        pd.Timestamp("2024-08-29"),
+    ]
+
+
+def test_detect_current_season_handles_prepared_df():
+    df = pd.DataFrame(
+        {
+            "Date": [
+                "30/05/2024",
+                "15/08/2024",
+                "22/08/2024",
+                "29/08/2024",
+            ],
+            "HomeTeam": ["A", "B", "C", "D"],
+            "AwayTeam": ["E", "F", "G", "H"],
+        }
+    )
+
+    df = prepare_df(df)
+    season_df, season_start = detect_current_season(
+        df, gap_days=30, prepared=True
+    )
 
     assert season_start == pd.Timestamp("2024-08-15")
     assert list(season_df["Date"]) == [

--- a/utils/poisson_utils/data.py
+++ b/utils/poisson_utils/data.py
@@ -63,7 +63,11 @@ def load_data(file_path: str) -> pd.DataFrame:
 
 
 def detect_current_season(
-    df: pd.DataFrame, *, start_month: int = 8, gap_days: int = 30
+    df: pd.DataFrame,
+    *,
+    start_month: int = 8,
+    gap_days: int = 30,
+    prepared: bool = False,
 ) -> tuple:
     """Return matches belonging to the current season.
 
@@ -83,6 +87,9 @@ def detect_current_season(
         Month used as a fallback start when no large breaks are present.
     gap_days : int, optional
         Minimum number of days considered a break between seasons.
+    prepared : bool, optional
+        Set to ``True`` if ``df`` has already been processed by
+        :func:`prepare_df` to avoid running it twice.
 
     Returns
     -------
@@ -91,7 +98,8 @@ def detect_current_season(
         from the detected season.
     """
 
-    df = prepare_df(df)
+    if not prepared:
+        df = prepare_df(df)
 
     # Work only with past matches to avoid jumping to the next season because
     # of fixtures far in the future.


### PR DESCRIPTION
## Summary
- add a `prepared` flag to `detect_current_season` to skip `prepare_df` when data already processed
- update app loader to pass prepared data and avoid duplicate preparation
- cover `prepared` flag with a dedicated test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68988659089c8329b6c13a8a7454ae48