### PR TITLE
Handle timezone-aware dates when preparing match data

### DIFF
--- a/tests/test_detect_current_season.py
+++ b/tests/test_detect_current_season.py
@@ -53,3 +53,31 @@ def test_detect_current_season_handles_prepared_df():
         pd.Timestamp("2024-08-22"),
         pd.Timestamp("2024-08-29"),
     ]
+
+
+def test_prepare_df_removes_timezone_information():
+    df = pd.DataFrame(
+        {
+            "Date": [
+                "30/05/2024 00:00+00:00",
+                "15/08/2024 00:00+00:00",
+                "22/08/2024 00:00+00:00",
+                "29/08/2024 00:00+00:00",
+            ],
+            "HomeTeam": ["A", "B", "C", "D"],
+            "AwayTeam": ["E", "F", "G", "H"],
+        }
+    )
+
+    prepared = prepare_df(df)
+    assert prepared["Date"].dt.tz is None
+    season_df, season_start = detect_current_season(
+        prepared, gap_days=30, prepared=True
+    )
+
+    assert season_start == pd.Timestamp("2024-08-15")
+    assert list(season_df["Date"]) == [
+        pd.Timestamp("2024-08-15"),
+        pd.Timestamp("2024-08-22"),
+        pd.Timestamp("2024-08-29"),
+    ]

--- a/utils/poisson_utils/data.py
+++ b/utils/poisson_utils/data.py
@@ -4,7 +4,7 @@ import pandas as pd
 def prepare_df(df: pd.DataFrame) -> pd.DataFrame:
     """Základní úprava dat: kopírování, převod datumu, odstranění nevalidních řádků, seřazení podle data."""
     df = df.copy()
-    df['Date'] = pd.to_datetime(df['Date'], dayfirst=True, errors='coerce')
+    df['Date'] = pd.to_datetime(df['Date'], dayfirst=True, errors='coerce').dt.tz_localize(None)
     df = df.dropna(subset=["Date", "HomeTeam", "AwayTeam"])
     df = df[df["HomeTeam"].astype(str).str.strip() != ""]
     df = df[df["AwayTeam"].astype(str).str.strip() != ""]


### PR DESCRIPTION
## Summary
- Strip timezone information from match dates in `prepare_df` to avoid type errors when comparing timestamps
- Add regression test verifying timezone removal and season detection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898909acf00832997cc5f7b2ed0fc2e