### PR TITLE
Handle pandas NA in safe_stat

### DIFF
--- a/tests/test_safe_stat_pd_na.py
+++ b/tests/test_safe_stat_pd_na.py
@@ -1,0 +1,26 @@
+import pandas as pd
+
+from utils.poisson_utils.team_analysis import (
+    expected_goals_combined_homeaway_allmatches,
+)
+
+
+def test_expected_goals_handles_pandas_na():
+    df = pd.DataFrame(
+        {
+            "Date": pd.to_datetime(["2024-01-01"]),
+            "HomeTeam": ["Existing"],
+            "AwayTeam": ["Other"],
+            "FTHG": pd.Series([1], dtype="Int64"),
+            "FTAG": pd.Series([1], dtype="Int64"),
+        }
+    )
+
+    elo = {"Missing": 1500, "Existing": 1500, "Other": 1500}
+
+    home, away = expected_goals_combined_homeaway_allmatches(
+        df, "Missing", "Existing", elo
+    )
+
+    assert isinstance(home, float)
+    assert isinstance(away, float)

--- a/utils/poisson_utils/team_analysis.py
+++ b/utils/poisson_utils/team_analysis.py
@@ -526,7 +526,7 @@ def expected_goals_combined_homeaway_allmatches(
 
     def safe_stat(series, default=1.0):
         val = series.mean()
-        return val if not np.isnan(val) else default
+        return val if not pd.isna(val) else default
 
     def get_home_away_exp(sub, team, is_home):
         df_team = sub[sub['HomeTeam'] == team] if is_home else sub[sub['AwayTeam'] == team]


### PR DESCRIPTION
## Summary
- avoid TypeError by checking pandas NA with `pd.isna` in team_analysis
- add regression test for expected_goals_combined_homeaway_allmatches

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68989355afbc8329970c04dc2591eb6e