### PR TITLE
Use container width for match prediction table

### DIFF
--- a/sections/match_prediction_section.py
+++ b/sections/match_prediction_section.py
@@ -376,7 +376,7 @@ def render_single_match_prediction(df, season_df, home_team, away_team, league_n
         
         df_disp = pd.DataFrame(data).T
         df_disp = df_disp[["Zápasy", "Góly", "Obdržené", "Střely", "Na branku", "xG", "Body/zápas", "Čistá konta %"]]
-        st.dataframe(df_disp)
+        st.dataframe(df_disp, use_container_width=True)
 
     display_merged_table(merged_home_away_opponent_form(df, home_team), home_team, strength_home)
     display_merged_table(merged_home_away_opponent_form(df, away_team), away_team, strength_away)


### PR DESCRIPTION
## Summary
- Ensure `display_merged_table` uses `st.dataframe` with `use_container_width=True`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898a5dacf54832989b2d0250819f54a