### PR TITLE
Add desktop CSS rule for responsive Streamlit columns

### DIFF
--- a/utils/responsive.py
+++ b/utils/responsive.py
@@ -9,6 +9,9 @@ def init_responsive_layout() -> None:
         @media (max-width: 600px) {
           div[data-testid="column"] { flex: 1 1 100% !important; }
         }
+        @media (min-width: 601px) {
+          div[data-testid="column"] { flex: initial; }
+        }
         </style>
         """,
         unsafe_allow_html=True,


### PR DESCRIPTION
## Summary
- ensure mobile @media CSS closes correctly
- add desktop rule to restore default Streamlit column flex behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898aa94bddc83298ce39b6b0e54e88b