### PR TITLE
Hide index column in league overview table

### DIFF
--- a/sections/overview_section.py
+++ b/sections/overview_section.py
@@ -136,7 +136,9 @@ def render_league_overview(season_df, league_name, gii_dict, elo_dict):
     float_cols = summary_table_display.select_dtypes(include="float").columns
     format_dict = {col: "{:.1f}" for col in float_cols}
     format_dict["Tým"] = clickable_team_link
-    styled_table = summary_table_display.style.format(format_dict, escape=None)
+    styled_table = (
+        summary_table_display.style.format(format_dict, escape=None).hide(axis="index")
+    )
     st.markdown(styled_table.to_html(escape=False), unsafe_allow_html=True)
 
     st.markdown("### 🌟 Top 5 týmy")


### PR DESCRIPTION
## Summary
- Hide the auto-generated index column in league overview by applying pandas Styler `hide(axis="index")` before rendering.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898b09e486883298a07b8a94cb5b9ab