### PR TITLE
Vectorize clean sheet calculation

### DIFF
--- a/utils/statistics.py
+++ b/utils/statistics.py
@@ -18,10 +18,14 @@ def calculate_clean_sheets(df: pd.DataFrame, team: str) -> float:
         Percentage of matches with a clean sheet rounded to one decimal place.
     """
     team_matches = df[(df["HomeTeam"] == team) | (df["AwayTeam"] == team)]
-    cs = 0
-    for _, row in team_matches.iterrows():
-        if row["HomeTeam"] == team and row["FTAG"] == 0:
-            cs += 1
-        elif row["AwayTeam"] == team and row["FTHG"] == 0:
-            cs += 1
-    return round(100 * cs / len(team_matches), 1) if len(team_matches) > 0 else 0
+    team_matches = team_matches.assign(
+        is_clean_sheet=(
+            ((team_matches["HomeTeam"] == team) & (team_matches["FTAG"] == 0))
+            | ((team_matches["AwayTeam"] == team) & (team_matches["FTHG"] == 0))
+        )
+    )
+    return (
+        round(team_matches["is_clean_sheet"].mean() * 100, 1)
+        if not team_matches.empty
+        else 0
+    )


### PR DESCRIPTION
## Summary
- Replace loop-based clean sheet counting with vectorized DataFrame operations
- Compute clean sheet percentage via `is_clean_sheet` column mean

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899fc239dbc8329a9dee9b161d6476e