### PR TITLE
refactor: remove redundant numpy import

### DIFF
--- a/utils/anomaly_detection.py
+++ b/utils/anomaly_detection.py
@@ -4,7 +4,6 @@ def calculate_contrarian_risk_score(matrix, expected_goals, tempo_home, tempo_aw
     """
     Vyhodnotí riziko, že zápas nebude odpovídat očekávanému (např. místo nudného zápasu přestřelka).
     """
-    import numpy as np
 
     risk_score = 0.0
 


### PR DESCRIPTION
## Summary
- remove duplicate numpy import from `calculate_contrarian_risk_score`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a05e86e2483299155d225442b4698