### PR TITLE
feat: add universal home button

### DIFF
--- a/app.py
+++ b/app.py
@@ -65,6 +65,12 @@ LEAGUE_START_MONTH = {
     # ostatní implicitně 8
 }
 
+# --- Sidebar: Navigation ---
+if st.sidebar.button("🏠 Home"):
+    st.session_state.clear()
+    st.query_params.clear()
+    st.rerun()
+
 # --- Sidebar: Správa dat ---
 with st.sidebar.expander("🔧 Správa dat"):
     if st.button("🔄 Aktualizovat data z webu"):


### PR DESCRIPTION
## Summary
- add always-visible Home button in sidebar
- clearing query params and session state to return to main overview

## Testing
- `python -m py_compile app.py`
- `pytest`
- `streamlit run app.py --server.headless true`


------
https://chatgpt.com/codex/tasks/task_e_689a1ae69bd483298de5bc7814386bde