### PR TITLE
fix: avoid zero division when calculating conversion

### DIFF
--- a/tests/test_match_style.py
+++ b/tests/test_match_style.py
@@ -1,0 +1,29 @@
+import math
+import pandas as pd
+
+from utils.poisson_utils import calculate_match_style_score_per_match
+
+
+def test_calculate_match_style_score_handles_zero_shots_on_target():
+    df = pd.DataFrame({
+        "Date": ["2023-08-01"],
+        "HomeTeam": ["A"],
+        "AwayTeam": ["B"],
+        "FTHG": pd.Series([1], dtype="Int64"),
+        "FTAG": pd.Series([1], dtype="Int64"),
+        "HS": pd.Series([0], dtype="Int64"),
+        "AS": pd.Series([0], dtype="Int64"),
+        "HST": pd.Series([0], dtype="Int64"),
+        "AST": pd.Series([0], dtype="Int64"),
+        "HC": pd.Series([0], dtype="Int64"),
+        "AC": pd.Series([0], dtype="Int64"),
+        "HY": pd.Series([0], dtype="Int64"),
+        "AY": pd.Series([0], dtype="Int64"),
+        "HR": pd.Series([0], dtype="Int64"),
+        "AR": pd.Series([0], dtype="Int64"),
+        "HF": pd.Series([0], dtype="Int64"),
+        "AF": pd.Series([0], dtype="Int64"),
+    })
+
+    result = calculate_match_style_score_per_match(df)
+    assert math.isclose(result["Konverze"].iloc[0], 20.0, rel_tol=1e-9)

--- a/utils/poisson_utils/match_style.py
+++ b/utils/poisson_utils/match_style.py
@@ -192,7 +192,9 @@ def calculate_match_style_score_per_match(df: pd.DataFrame) -> pd.DataFrame:
     # Základní složky
     df['Tempo'] = df['HS'] + df['AS'] + df['HC'] + df['AC'] + df['HF'] + df['AF']
     df['Goly'] = df['FTHG'] + df['FTAG']
-    df['Konverze'] = (df['FTHG'] + df['FTAG']) / (df['HST'] + df['AST']).replace(0, 0.1)
+    # Replace zero shots on target with a small float to avoid division by zero
+    shots_on_target = (df['HST'] + df['AST']).astype(float).replace(0, 0.1)
+    df['Konverze'] = (df['FTHG'] + df['FTAG']) / shots_on_target
     df['Agrese'] = df['HY'] + df['AY'] + 2 * (df['HR'] + df['AR']) + df['HF'] + df['AF']
 
     # Normalizace pro složky do 0–1


### PR DESCRIPTION
## Summary
- handle zero shots on target when computing conversion rate
- add regression test for match style conversion metric

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a417cae4883298afc83a7458613b1