### PR TITLE
Fix match style score division error in warnings

### DIFF
--- a/tests/test_match_style.py
+++ b/tests/test_match_style.py
@@ -2,6 +2,9 @@ import math
 import pandas as pd
 
 from utils.poisson_utils import calculate_match_style_score_per_match
+from utils.utils_warnings import (
+    calculate_match_style_score_per_match as warnings_match_style_score,
+)
 
 
 def test_calculate_match_style_score_handles_zero_shots_on_target():
@@ -26,4 +29,29 @@ def test_calculate_match_style_score_handles_zero_shots_on_target():
     })
 
     result = calculate_match_style_score_per_match(df)
+    assert math.isclose(result["Konverze"].iloc[0], 20.0, rel_tol=1e-9)
+
+
+def test_warning_match_style_score_handles_zero_shots_on_target():
+    df = pd.DataFrame({
+        "Date": ["2023-08-01"],
+        "HomeTeam": ["A"],
+        "AwayTeam": ["B"],
+        "FTHG": pd.Series([1], dtype="Int64"),
+        "FTAG": pd.Series([1], dtype="Int64"),
+        "HS": pd.Series([0], dtype="Int64"),
+        "AS": pd.Series([0], dtype="Int64"),
+        "HST": pd.Series([0], dtype="Int64"),
+        "AST": pd.Series([0], dtype="Int64"),
+        "HC": pd.Series([0], dtype="Int64"),
+        "AC": pd.Series([0], dtype="Int64"),
+        "HY": pd.Series([0], dtype="Int64"),
+        "AY": pd.Series([0], dtype="Int64"),
+        "HR": pd.Series([0], dtype="Int64"),
+        "AR": pd.Series([0], dtype="Int64"),
+        "HF": pd.Series([0], dtype="Int64"),
+        "AF": pd.Series([0], dtype="Int64"),
+    })
+
+    result = warnings_match_style_score(df)
     assert math.isclose(result["Konverze"].iloc[0], 20.0, rel_tol=1e-9)

--- a/utils/utils_warnings.py
+++ b/utils/utils_warnings.py
@@ -864,7 +864,8 @@ def calculate_match_style_score_per_match(df):
     # Výpočty
     df["Tempo"] = df["HS"] + df["AS"] + df["HC"] + df["AC"] + df["HF"] + df["AF"]
     df["Goly"] = df["FTHG"] + df["FTAG"]
-    df["Konverze"] = (df["FTHG"] + df["FTAG"]) / (df["HST"] + df["AST"]).replace(0, 0.1)
+    shots_on_target = (df["HST"] + df["AST"]).astype(float).replace(0, 0.1)
+    df["Konverze"] = (df["FTHG"] + df["FTAG"]) / shots_on_target
     df["Agrese"] = df["HY"] + df["AY"] + 2 * (df["HR"] + df["AR"]) + df["HF"] + df["AF"]
 
     # Normalizace


### PR DESCRIPTION
## Summary
- avoid TypeError when calculating match style score by casting shots on target to float before zero replacement in `utils.utils_warnings`
- add regression tests covering zero shots on target for `utils.utils_warnings.calculate_match_style_score_per_match`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a3a92d3e48329ad0040a6ba902cf2