### PR TITLE
Fix nullable integer replace in match style calculations

### DIFF
--- a/utils/utils_warnings.py
+++ b/utils/utils_warnings.py
@@ -864,7 +864,13 @@ def calculate_match_style_score_per_match(df):
     # Výpočty
     df["Tempo"] = df["HS"] + df["AS"] + df["HC"] + df["AC"] + df["HF"] + df["AF"]
     df["Goly"] = df["FTHG"] + df["FTAG"]
-    shots_on_target = (df["HST"] + df["AST"]).astype(float).replace(0, 0.1)
+    # Pandas' nullable integer dtype causes `replace` to reject floating
+    # values when performed directly on the summed column.  Cast the input
+    # columns to float before addition so the result is a regular float Series
+    # and zeros can safely be replaced with a small non-zero value.
+    shots_on_target = (
+        df["HST"].astype(float) + df["AST"].astype(float)
+    ).replace(0, 0.1)
     df["Konverze"] = (df["FTHG"] + df["FTAG"]) / shots_on_target
     df["Agrese"] = df["HY"] + df["AY"] + 2 * (df["HR"] + df["AR"]) + df["HF"] + df["AF"]
 


### PR DESCRIPTION
## Summary
- Avoid TypeError when replacing zeros in shot counts by converting input columns to float before summing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a4518ef7c8329b3d6c9f533565062