### PR TITLE
Use full history for opponent stats

### DIFF
--- a/app.py
+++ b/app.py
@@ -131,6 +131,8 @@ if st.session_state.get("reload_flag"):
     del st.session_state["reload_flag"]
 
 df, season_df, gii_dict, elo_dict = load_and_prepare(league_file)
+# Zachováme kompletní dataset pro historické statistiky (H2H apod.)
+full_df = df.copy()
 
 # --- Date range filtr ---
 overall_start = df["Date"].min().date()
@@ -205,7 +207,14 @@ elif multi_prediction_mode:
 
 elif home_team != away_team:
     render_single_match_prediction(
-        df, season_df, home_team, away_team, league_name, gii_dict, elo_dict
+        df,
+        season_df,
+        full_df,
+        home_team,
+        away_team,
+        league_name,
+        gii_dict,
+        elo_dict,
     )
 
 else:

--- a/sections/match_prediction_section.py
+++ b/sections/match_prediction_section.py
@@ -202,7 +202,16 @@ def display_metrics(
 
 
 
-def render_single_match_prediction(df, season_df, home_team, away_team, league_name, gii_dict, elo_dict):
+def render_single_match_prediction(
+    df,
+    season_df,
+    full_df,
+    home_team,
+    away_team,
+    league_name,
+    gii_dict,
+    elo_dict,
+):
     st.header(f"🔮 {home_team} vs {away_team}")
 
     try:
@@ -378,13 +387,21 @@ def render_single_match_prediction(df, season_df, home_team, away_team, league_n
         df_disp = df_disp[["Zápasy", "Góly", "Obdržené", "Střely", "Na branku", "xG", "Body/zápas", "Čistá konta %"]]
         st.dataframe(df_disp, use_container_width=True)
 
-    display_merged_table(merged_home_away_opponent_form(df, home_team), home_team, strength_home)
-    display_merged_table(merged_home_away_opponent_form(df, away_team), away_team, strength_away)
+    display_merged_table(
+        merged_home_away_opponent_form(full_df, home_team),
+        home_team,
+        strength_home,
+    )
+    display_merged_table(
+        merged_home_away_opponent_form(full_df, away_team),
+        away_team,
+        strength_away,
+    )
 
     # Head-to-head statistiky
     # Head-to-Head – kompaktní přehled
     st.markdown("## 💬 Head-to-Head")
-    h2h = get_head_to_head_stats(df, home_team, away_team)
+    h2h = get_head_to_head_stats(full_df, home_team, away_team, last_n=None)
 
     if h2h:
         h2h_cols = responsive_columns(6)

--- a/utils/poisson_utils/team_analysis.py
+++ b/utils/poisson_utils/team_analysis.py
@@ -241,14 +241,26 @@ def analyze_opponent_strength(df: pd.DataFrame, team: str, is_home: bool = True)
     }
 
 
-def get_head_to_head_stats(df: pd.DataFrame, home_team: str, away_team: str, last_n: int = 5) -> dict | None:
-    """Vrací head-to-head statistiky za posledních N zápasů mezi dvěma týmy."""
+def get_head_to_head_stats(
+    df: pd.DataFrame,
+    home_team: str,
+    away_team: str,
+    last_n: int | None = 5,
+) -> dict | None:
+    """Vrací head-to-head statistiky za posledních ``last_n`` zápasů.
+
+    Pokud je ``last_n`` ``None``, použijí se všechna dostupná utkání z
+    poskytnutého datasetu.
+    """
     df = prepare_df(df)
 
     h2h = df[
         ((df['HomeTeam'] == home_team) & (df['AwayTeam'] == away_team)) |
         ((df['HomeTeam'] == away_team) & (df['AwayTeam'] == home_team))
-    ].sort_values('Date', ascending=False).head(last_n)
+    ].sort_values('Date', ascending=False)
+
+    if last_n is not None:
+        h2h = h2h.head(last_n)
 
     if h2h.empty:
         return None


### PR DESCRIPTION
## Summary
- Preserve full league dataset for historical stats and pass it to match predictions
- Use complete match history for opponent-type performance tables and head-to-head figures
- Allow `get_head_to_head_stats` to return all matches when desired

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a498e5a0483299dfaed787f395a46