### PR TITLE
Use WhoScored xG data in team detail section

### DIFF
--- a/utils/poisson_utils/__init__.py
+++ b/utils/poisson_utils/__init__.py
@@ -92,4 +92,4 @@ from .corners import (
     corner_over_under_prob,
 )
 
-from .whoscored_api import get_whoscored_xg
+from .whoscored_api import get_whoscored_xg, get_whoscored_xg_xga


### PR DESCRIPTION
## Summary
- Fetch team xG/xGA from WhoScored with on-disk caching and backwards-compatible helper.
- Replace pseudo-xG usage in the team detail view with WhoScored data, falling back to pseudo values when missing.
- Surface xG and xGA in the team's statistics table.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b6691428c8329adb88a0f4ed39dc0