### PR TITLE
Add editable My Bets section

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,7 @@ from sections.overview_section import render_league_overview
 from sections.match_prediction_section import render_single_match_prediction
 from sections.multi_prediction_section import render_multi_match_predictions
 from sections.team_detail_section import render_team_detail
+from sections.my_bets_section import render_my_bets_section
 
 import urllib.parse
 from utils.poisson_utils import (
@@ -165,9 +166,10 @@ if "match_list" not in st.session_state:
 
 # --- Výběr týmů ---
 teams_in_season = sorted(set(season_df["HomeTeam"].unique()) | set(season_df["AwayTeam"].unique()))
-home_team = st.sidebar.selectbox("Domácí tým", teams_in_season)
-away_team = st.sidebar.selectbox("Hostující tým", teams_in_season)
-multi_prediction_mode = st.sidebar.checkbox("📝 Hromadné predikce")
+  home_team = st.sidebar.selectbox("Domácí tým", teams_in_season)
+  away_team = st.sidebar.selectbox("Hostující tým", teams_in_season)
+  multi_prediction_mode = st.sidebar.checkbox("📝 Hromadné predikce")
+  my_bets_mode = st.sidebar.checkbox("📒 My Bets")
 
 # --- Query params ---
 query_params = st.query_params
@@ -192,7 +194,10 @@ elif st.session_state["last_selected_league"] != league_name:
     st.rerun()
 
 # === ROUTING ===
-if selected_team:
+if my_bets_mode:
+    render_my_bets_section()
+
+elif selected_team:
     render_team_detail(df, season_df, selected_team, league_name, gii_dict)
     if st.button("🔙 Zpět na ligový přehled"):
         st.query_params.clear()

--- a/sections/my_bets_section.py
+++ b/sections/my_bets_section.py
@@ -1,0 +1,93 @@
+import streamlit as st
+import pandas as pd
+from io import BytesIO
+from utils import bet_db
+
+
+RESULT_OPTIONS = ["pending", "win", "loss", "push"]
+
+
+def _calc_profit(result: str, stake: float, odds: float) -> float | None:
+    """Return profit based on bet result."""
+    if result == "win":
+        return (odds - 1) * stake
+    if result == "loss":
+        return -stake
+    if result == "push":
+        return 0.0
+    return None
+
+
+def render_my_bets_section() -> None:
+    """Display recorded bets with edit and export options."""
+    st.title("📒 My Bets")
+
+    stats = bet_db.compute_stats()
+    cols = st.columns(2)
+    cols[0].metric("ROI", f"{stats['roi']*100:.1f}%")
+    cols[1].metric("Success Rate", f"{stats['win_rate']*100:.1f}%")
+
+    bets = bet_db.fetch_bets()
+    if not bets:
+        st.info("No bets recorded.")
+        return
+
+    df = pd.DataFrame(bets)
+
+    edited_df = st.data_editor(
+        df,
+        column_config={
+            "result": st.column_config.SelectboxColumn("Result", options=RESULT_OPTIONS),
+            "odds": st.column_config.NumberColumn("Odds", min_value=1.0, step=0.01),
+            "stake": st.column_config.NumberColumn("Stake", min_value=0.0, step=0.1),
+        },
+        disabled=[
+            "id",
+            "league",
+            "home_team",
+            "away_team",
+            "bet_type",
+            "profit",
+            "created_at",
+        ],
+        hide_index=True,
+        use_container_width=True,
+        key="bets_editor",
+    )
+
+    if st.button("💾 Update bets"):
+        for row in edited_df.itertuples(index=False):
+            original = df[df["id"] == row.id].iloc[0]
+            updates = {}
+            if row.result != original["result"]:
+                updates["result"] = row.result
+            if row.odds != original["odds"]:
+                updates["odds"] = float(row.odds)
+            if row.stake != original["stake"]:
+                updates["stake"] = float(row.stake)
+            if updates:
+                profit = _calc_profit(row.result, float(row.stake), float(row.odds))
+                updates["profit"] = profit
+                bet_db.update_bet(row.id, **updates)
+        st.success("Bets updated")
+        st.rerun()
+
+    st.markdown("### Delete bet")
+    del_id = st.selectbox("Select bet ID", df["id"], key="delete_select")
+    if st.button("🗑️ Delete selected bet"):
+        bet_db.delete_bet(int(del_id))
+        st.success("Bet deleted")
+        st.rerun()
+
+    csv = df.to_csv(index=False).encode("utf-8")
+    st.download_button("⬇️ Download CSV", csv, file_name="bets.csv", mime="text/csv")
+
+    excel_buffer = BytesIO()
+    with pd.ExcelWriter(excel_buffer, engine="xlsxwriter") as writer:
+        df.to_excel(writer, index=False)
+    st.download_button(
+        "⬇️ Download Excel",
+        excel_buffer.getvalue(),
+        file_name="bets.xlsx",
+        mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )

--- a/utils/bet_db.py
+++ b/utils/bet_db.py
@@ -79,6 +79,13 @@ def update_bet(bet_id: int, **fields: Any) -> None:
         conn.commit()
 
 
+def delete_bet(bet_id: int) -> None:
+    """Remove a bet from the database by id."""
+    with _get_connection() as conn:
+        conn.execute("DELETE FROM bets WHERE id = ?", (bet_id,))
+        conn.commit()
+
+
 def fetch_bets() -> List[Dict[str, Any]]:
     """Return all bets as a list of dicts ordered by creation time."""
     with _get_connection() as conn:


### PR DESCRIPTION
## Summary
- Add My Bets section to manage recorded wagers with ROI metrics
- Support updating results, odds and stakes with profit calculation and deletion
- Allow CSV/Excel export and integrate section into app navigation

## Testing
- `pytest`
- `python -m py_compile sections/my_bets_section.py utils/bet_db.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0760942108329b7bc8aa4eec413ed