### PR TITLE
Expand sidebar by default

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,7 +43,7 @@ st.set_page_config(
     page_title="⚽ Poisson Predictor",
     page_icon="⚽",
     layout=layout,
-    initial_sidebar_state="collapsed",
+    initial_sidebar_state="expanded",
 )
 init_responsive_layout()
 pd.options.display.float_format = lambda x: f"{x:.1f}"


### PR DESCRIPTION
## Summary
- Expand Streamlit sidebar on startup so "My Bets" is visible immediately.

## Testing
- `python -m streamlit run app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a07bae6bf883299c24a9d1229fc9c7