### PR TITLE
Adjust default stake and odds

### DIFF
--- a/sections/match_prediction_section.py
+++ b/sections/match_prediction_section.py
@@ -415,8 +415,8 @@ def render_single_match_prediction(
                 f"{away_team} -1.0",
             ],
         )
-        odds = st.number_input("Odds", min_value=1.0, value=1.0, step=0.01)
-        stake = st.number_input("Stake", min_value=0.0, value=1.0, step=0.1)
+        odds = st.number_input("Odds", min_value=1.0, value=1.5, step=0.01)
+        stake = st.number_input("Stake", min_value=0.0, value=100.0, step=0.1)
         if st.form_submit_button("Save bet"):
             bet_db.insert_bet(
                 league=league_name,


### PR DESCRIPTION
## Summary
- set default odd to 1.5 and stake to 100 in match predictions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0c445a6248329bf5eb683f218f1af