### PR TITLE
Cache CSV loads as Parquet and add conversion CLI

### DIFF
--- a/convert_csvs_to_parquet.py
+++ b/convert_csvs_to_parquet.py
@@ -1,0 +1,36 @@
+import argparse
+from pathlib import Path
+
+from utils.poisson_utils.data import load_data
+
+
+def convert_path(path: Path) -> None:
+    """Convert CSV files to Parquet using :func:`load_data`.
+
+    ``load_data`` automatically writes a Parquet file next to the CSV when it
+    reads one. This helper simply calls it for each provided path.
+    """
+    if path.is_dir():
+        for csv_file in path.glob("*.csv"):
+            load_data(str(csv_file))
+    elif path.suffix.lower() == ".csv" and path.exists():
+        load_data(str(path))
+    else:
+        print(f"Skipping {path}: not a CSV file or directory", flush=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Preconvert CSV files to Parquet for faster future loads"
+    )
+    parser.add_argument(
+        "paths", nargs="+", help="CSV files or directories containing CSVs"
+    )
+    args = parser.parse_args()
+
+    for p in args.paths:
+        convert_path(Path(p))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_load_data_parquet.py
+++ b/tests/test_load_data_parquet.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import utils.poisson_utils.data as data
+
+
+def test_load_data_writes_and_reads_parquet(tmp_path):
+    csv_path = tmp_path / "sample.csv"
+    csv_path.write_text(
+        "Date,HomeTeam,AwayTeam,FTHG,FTAG,FTR,HS,AS,HST,AST,HC,AC,HY,AY,HR,AR,HF,AF\n"
+        "01/01/2024,A,B,1,0,H,5,3,2,1,4,2,1,0,0,0,3,5\n"
+    )
+
+    df1 = data.load_data(str(csv_path))
+    parquet_path = csv_path.with_suffix(".parquet")
+    assert parquet_path.exists()
+
+    csv_path.unlink()
+    df2 = data.load_data(str(csv_path))
+
+    pd.testing.assert_frame_equal(df1, df2)

--- a/utils/poisson_utils/data.py
+++ b/utils/poisson_utils/data.py
@@ -40,6 +40,7 @@ def load_data(file_path: str) -> pd.DataFrame:
     else:
         dtype_mapping = {col: "Int64" for col in numeric_columns}
         df = pd.read_csv(file_path, dtype=dtype_mapping, parse_dates=["Date"])
+        df.to_parquet(parquet_path, index=False)
 
     df = prepare_df(df)
     required_columns = [


### PR DESCRIPTION
## Summary
- Persist CSV league data as Parquet on first load for faster subsequent reads
- Add `convert_csvs_to_parquet.py` helper to preconvert existing CSV files
- Test that load_data writes a Parquet file and can reload from it when the CSV is absent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0c82063e08329b6db6ce6c8c50543