### PR TITLE
Add plotly dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ scipy
 streamlit
 matplotlib
 seaborn
+plotly
 XlsxWriter>=3.0.0
 
 requests


### PR DESCRIPTION
## Summary
- Include `plotly` in requirements to support visualization modules.

## Testing
- `pip install plotly` *(fails: Could not find a version that satisfies the requirement plotly)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0ce24435c83299c73bb0ce3e55667