### PR TITLE
Guard against non-mapping style data in radar chart

### DIFF
--- a/sections/match_prediction_section.py
+++ b/sections/match_prediction_section.py
@@ -2,6 +2,7 @@ import streamlit as st
 import pandas as pd
 import numpy as np
 from typing import Any, Dict, List, Tuple
+from collections.abc import Mapping
 from utils.responsive import responsive_columns
 from utils.poisson_utils import (
     expected_goals_weighted_by_elo,
@@ -579,18 +580,18 @@ def render_single_match_prediction(
 
 
     
-    style_home = get_team_style_vs_opponent_type(full_df, home_team, away_team) or {}
-    style_away = get_team_style_vs_opponent_type(full_df, away_team, home_team) or {}
+    style_home = get_team_style_vs_opponent_type(full_df, home_team, away_team)
+    style_away = get_team_style_vs_opponent_type(full_df, away_team, home_team)
     st.divider()
     radar_cols = st.columns(4)
-    if style_home:
+    if isinstance(style_home, Mapping) and style_home:
         radar_cols[0].plotly_chart(
             plot_style_radar(style_home), use_container_width=True
         )
         radar_cols[0].caption(
             " | ".join(TEAM_COMPARISON_DESC_MAP.get(k, k) for k in style_home)
         )
-    if style_away:
+    if isinstance(style_away, Mapping) and style_away:
         radar_cols[1].plotly_chart(
             plot_style_radar(style_away), use_container_width=True
         )

--- a/utils/radar_chart.py
+++ b/utils/radar_chart.py
@@ -1,8 +1,20 @@
+"""Utilities for plotting radar charts.
+
+The original implementation expected a ``dict`` of statistics, but in
+practice the caller occasionally passed other data types (such as a
+single ``float``).  This resulted in an ``AttributeError`` when the
+function attempted to access ``.keys`` on a non-mapping object.  To make
+the function robust we now accept any ``Mapping`` and gracefully handle
+invalid inputs by returning an empty figure.
+"""
+
+from collections.abc import Mapping
+from typing import Any
+
 import plotly.graph_objects as go
-from typing import Dict, Any
 
 
-def plot_style_radar(stats_dict: Dict[str, Any]) -> go.Figure:
+def plot_style_radar(stats_dict: Mapping[str, Any]) -> go.Figure:
     """Create a simple radar chart for style metrics.
 
     Parameters
@@ -15,7 +27,7 @@ def plot_style_radar(stats_dict: Dict[str, Any]) -> go.Figure:
     go.Figure
         Plotly radar chart visualising the provided metrics.
     """
-    if not stats_dict:
+    if not isinstance(stats_dict, Mapping) or not stats_dict:
         return go.Figure()
 
     categories = list(stats_dict.keys())


### PR DESCRIPTION
## Summary
- Avoid AttributeError in radar chart by validating input is a Mapping before use
- Skip rendering radar charts when style data is not a mapping in match prediction section

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0dde755fc832999dcd4600494d2ba