### PR TITLE
Validate required columns for expected corners

### DIFF
--- a/tests/test_corner_utils.py
+++ b/tests/test_corner_utils.py
@@ -1,5 +1,6 @@
 import math
 import pandas as pd
+import pytest
 
 from utils.poisson_utils import expected_corners, poisson_corner_matrix, corner_over_under_prob
 
@@ -19,6 +20,21 @@ def test_expected_corners():
     home, away = expected_corners(df, "A", "B")
     assert math.isclose(home, 5.5, rel_tol=1e-4)
     assert math.isclose(away, 3.25, rel_tol=1e-4)
+
+
+@pytest.mark.parametrize("missing", ["HC", "AC", "HomeTeam", "AwayTeam"])
+def test_expected_corners_missing_column(missing):
+    df = _sample_df().drop(columns=[missing])
+    with pytest.raises(ValueError, match=missing):
+        expected_corners(df, "A", "B")
+
+
+def test_expected_corners_multiple_missing_columns():
+    df = _sample_df().drop(columns=["HC", "AC"])
+    with pytest.raises(ValueError) as exc:
+        expected_corners(df, "A", "B")
+    msg = str(exc.value)
+    assert "HC" in msg and "AC" in msg
 
 
 def test_corner_over_under_probabilities_sum_to_100():

--- a/utils/poisson_utils/corners.py
+++ b/utils/poisson_utils/corners.py
@@ -11,6 +11,14 @@ def expected_corners(df: pd.DataFrame, home_team: str, away_team: str) -> tuple:
     the opponent's corners conceded in the corresponding venue (home/away).
     If any component is missing, it is ignored in the average and defaulted to 0.
     """
+
+    required_columns = {"HC", "AC", "HomeTeam", "AwayTeam"}
+    missing_columns = required_columns - set(df.columns)
+    if missing_columns:
+        raise ValueError(
+            f"Missing columns: {', '.join(sorted(missing_columns))}"
+        )
+
     df = prepare_df(df)
 
     home_for = df[df['HomeTeam'] == home_team]['HC'].mean()


### PR DESCRIPTION
## Summary
- ensure `expected_corners` checks for required corner columns before preparing data
- add tests for missing corner columns

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0e3513b548329ae7782757cc68168