### PR TITLE
Handle pd.NA in team goal average calculations

### DIFF
--- a/utils/utils_warnings.py
+++ b/utils/utils_warnings.py
@@ -29,13 +29,12 @@ def calculate_team_goal_averages(df):
     for team in teams:
         home_avg = df[df['HomeTeam'] == team]['FTHG'].mean()
         away_avg = df[df['AwayTeam'] == team]['FTAG'].mean()
-        # ``np.nanmean`` does not handle ``pd.NA`` values that can appear when
-        # operating on pandas' nullable dtypes.  Convert the values to a
-        # float-based ``Series`` so that any ``pd.NA`` is cast to ``np.nan`` and
-        # then compute the mean while skipping missing values.
-        avg_goals[team] = (
-            pd.Series([home_avg, away_avg], dtype="float64").mean(skipna=True)
-        )
+        # ``home_avg``/``away_avg`` can be ``pd.NA`` when the source columns use
+        # pandas' nullable dtypes.  ``np.nanmean`` does not understand
+        # ``pd.NA`` values, so coerce them to ``np.nan`` before computing the
+        # mean.
+        values = pd.to_numeric([home_avg, away_avg], errors="coerce")
+        avg_goals[team] = np.nanmean(values)
     return avg_goals
 
 def form_points_to_emoji(avg_points):


### PR DESCRIPTION
## Summary
- fix `calculate_team_goal_averages` to coerce nullable results to numeric before averaging
- prevent TypeError when team statistics contain `pd.NA`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0e7aea7048329b9695db585c28523