### PR TITLE
Handle pd.NA in goal averages and empty tempo lists

### DIFF
--- a/utils/poisson_utils/match_style.py
+++ b/utils/poisson_utils/match_style.py
@@ -103,16 +103,20 @@ def calculate_match_tempo(df: pd.DataFrame, team: str, opponent_elo: float, is_h
             f = pd.concat([home['HF'], away['AF']])
             all_tempos.append((s + c + f).median())
 
-    percentile = round(sum(t < tempo_index for t in all_tempos) / len(all_tempos) * 100, 1)
+    if all_tempos:
+        percentile = round(sum(t < tempo_index for t in all_tempos) / len(all_tempos) * 100, 1)
 
-    if percentile >= 80:
-        rating = "⚡ velmi rychlé"
-    elif percentile >= 40:
-        rating = "🎯 střední tempo"
-    elif percentile >= 10:
-        rating = "💤 pomalé"
+        if percentile >= 80:
+            rating = "⚡ velmi rychlé"
+        elif percentile >= 40:
+            rating = "🎯 střední tempo"
+        elif percentile >= 10:
+            rating = "💤 pomalé"
+        else:
+            rating = "🪨 velmi pomalé"
     else:
-        rating = "🪨 velmi pomalé"
+        percentile = 0
+        rating = "N/A"
 
     # ⚖️ IMBALANCE – jen proti soupeřům stejné síly
     


### PR DESCRIPTION
## Summary
- fix `calculate_team_goal_averages` to coerce nullable results to numeric before averaging
- avoid division by zero in tempo percentile calculations when league data is insufficient

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0e7aea7048329b9695db585c28523