### PR TITLE
Add cross-league team strength index

### DIFF
--- a/tests/test_cross_league_team_index.py
+++ b/tests/test_cross_league_team_index.py
@@ -1,0 +1,29 @@
+import pandas as pd
+import pytest
+
+from utils.poisson_utils import calculate_cross_league_team_index
+
+
+def test_cross_league_team_index_basic():
+    teams = pd.DataFrame(
+        {
+            "league": ["A", "A", "B"],
+            "team": ["A1", "A2", "B1"],
+            "matches": [2, 2, 2],
+            "goals_for": [4, 2, 3],
+            "goals_against": [1, 2, 2],
+            "xg_for": [3.0, 1.0, 2.0],
+            "xg_against": [1.0, 2.0, 1.0],
+        }
+    )
+    ratings = pd.DataFrame({"league": ["A", "B"], "elo": [1600, 1400]})
+
+    result = calculate_cross_league_team_index(teams, ratings)
+
+    # team_index should rank A1 highest, B1 second, A2 lowest
+    ordered = list(result.sort_values("team_index", ascending=False)["team"])
+    assert ordered == ["A1", "B1", "A2"]
+
+    # check expected value for A1 approximately
+    a1_index = result.loc[result["team"] == "A1", "team_index"].item()
+    assert a1_index == pytest.approx(21.94, rel=1e-2)

--- a/utils/poisson_utils/__init__.py
+++ b/utils/poisson_utils/__init__.py
@@ -93,3 +93,4 @@ from .corners import (
 )
 
 from .whoscored_api import get_whoscored_xg, get_whoscored_xg_xga
+from .cross_league import calculate_cross_league_team_index

--- a/utils/poisson_utils/cross_league.py
+++ b/utils/poisson_utils/cross_league.py
@@ -1,0 +1,61 @@
+import pandas as pd
+
+
+def calculate_cross_league_team_index(df: pd.DataFrame, league_ratings: pd.DataFrame) -> pd.DataFrame:
+    """Return league-adjusted team ratings to compare clubs across leagues.
+
+    Parameters
+    ----------
+    df: pd.DataFrame
+        Team statistics with columns ``league``, ``team``, ``matches`` and
+        metrics like ``goals_for``, ``goals_against``, ``xg_for``, ``xg_against``
+        (optionally ``shots_for`` and ``shots_against``). Values should be totals
+        across the provided matches.
+    league_ratings: pd.DataFrame
+        Table of league strength ratings with columns ``league`` and ``elo``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Original DataFrame extended with per-match metrics, normalised xG ratio
+        and a ``team_index`` scaled by league strength. Higher values indicate a
+        stronger team relative to world average.
+    """
+    metrics = [
+        "goals_for",
+        "goals_against",
+        "xg_for",
+        "xg_against",
+        "shots_for",
+        "shots_against",
+    ]
+
+    df = df.copy()
+    available = [m for m in metrics if m in df.columns]
+    if "matches" not in df.columns or df["matches"].eq(0).any():
+        raise ValueError("DataFrame must contain 'matches' column with non-zero values")
+
+    # convert to per-match values (per 90 minutes)
+    df[available] = df[available].div(df["matches"], axis=0)
+
+    # xG ratio relative to league average
+    if {"xg_for", "xg_against"}.issubset(df.columns):
+        df["xg_ratio"] = df["xg_for"] / df["xg_against"].replace(0, pd.NA)
+        df["xg_league_avg"] = df.groupby("league")["xg_ratio"].transform("mean")
+        df["xg_vs_league"] = df["xg_ratio"] / df["xg_league_avg"]
+    else:
+        df["xg_vs_league"] = 1.0
+
+    # merge league strength and scale to world average
+    df = df.merge(league_ratings, on="league", how="left")
+    if df["elo"].isna().any():
+        raise ValueError("Missing ELO rating for some leagues")
+    elo_mean = league_ratings["elo"].mean()
+    df["xg_vs_world"] = df["xg_vs_league"] * (df["elo"] / elo_mean)
+
+    # simple offensive/defensive ratings
+    df["off_rating"] = df["goals_for"] / df["goals_against"].replace(0, pd.NA)
+    df["def_rating"] = df["xg_against"] / df["xg_for"].replace(0, pd.NA)
+
+    df["team_index"] = df["off_rating"] * (1 / df["def_rating"]) * df["xg_vs_world"]
+    return df


### PR DESCRIPTION
## Summary
- add `calculate_cross_league_team_index` to normalize team stats and adjust for league strength
- expose function via `utils.poisson_utils` and cover with unit test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0ff32707c8329ae5a7fdb55899b3c