### PR TITLE
Add cross-league index view

### DIFF
--- a/sections/cross_league_section.py
+++ b/sections/cross_league_section.py
@@ -1,0 +1,34 @@
+import streamlit as st
+import pandas as pd
+
+def render_cross_league_index(df: pd.DataFrame) -> None:
+    """Display cross-league team index with optional filtering."""
+
+    st.header("🌍 Cross-League Team Index")
+
+    if df.empty:
+        st.info("No team data available.")
+        return
+
+    leagues = sorted(df["league"].unique())
+    selected_leagues = st.multiselect("Leagues", leagues, default=leagues)
+    filtered = df[df["league"].isin(selected_leagues)]
+
+    teams = sorted(filtered["team"].unique())
+    selected_teams = st.multiselect("Teams", teams)
+    if selected_teams:
+        filtered = filtered[filtered["team"].isin(selected_teams)]
+
+    display_cols = [
+        "league",
+        "team",
+        "team_index",
+        "xg_vs_world",
+        "off_rating",
+        "def_rating",
+    ]
+    st.dataframe(
+        filtered.sort_values("team_index", ascending=False)[display_cols].reset_index(drop=True),
+        hide_index=True,
+        use_container_width=True,
+    )


### PR DESCRIPTION
## Summary
- import and compute cross-league team index for all leagues
- provide new navigation view to explore cross-league ratings
- show cross-league team index with filtering options

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1092a6d308329b4f8a3a2f34c9025