### PR TITLE
Improve cross-league index metrics documentation

### DIFF
--- a/tests/test_cross_league_team_index.py
+++ b/tests/test_cross_league_team_index.py
@@ -1,0 +1,53 @@
+import pandas as pd
+import pytest
+
+from utils.poisson_utils import (
+    calculate_cross_league_team_index,
+    CROSS_LEAGUE_COLUMN_LEGEND,
+)
+
+
+def test_cross_league_team_index_basic():
+    teams = pd.DataFrame(
+        {
+            "league": ["A", "A", "B"],
+            "team": ["A1", "A2", "B1"],
+            "matches": [2, 2, 2],
+            "goals_for": [4, 2, 3],
+            "goals_against": [1, 2, 2],
+            "xg_for": [3.0, 1.0, 2.0],
+            "xg_against": [1.0, 2.0, 1.0],
+        }
+    )
+    ratings = pd.DataFrame({"league": ["A", "B"], "elo": [1600, 1400]})
+
+    result = calculate_cross_league_team_index(teams, ratings)
+
+    # cross_league_index should rank A1 highest, B1 second, A2 lowest
+    ordered = list(result.sort_values("cross_league_index", ascending=False)["team"])
+    assert ordered == ["A1", "B1", "A2"]
+
+    # check expected value for A1 approximately
+    a1_index = result.loc[result["team"] == "A1", "cross_league_index"].item()
+    assert a1_index == pytest.approx(21.94, rel=1e-2)
+
+
+def test_columns_have_legend():
+    teams = pd.DataFrame(
+        {
+            "league": ["A"],
+            "team": ["A1"],
+            "matches": [2],
+            "goals_for": [4],
+            "goals_against": [1],
+            "xg_for": [3.0],
+            "xg_against": [1.0],
+        }
+    )
+    ratings = pd.DataFrame({"league": ["A"], "elo": [1600]})
+
+    result = calculate_cross_league_team_index(teams, ratings)
+    # ensure each returned metric is documented in legend
+    for col in result.columns:
+        if col not in {"league", "team", "matches", "elo"}:  # original fields
+            assert col in CROSS_LEAGUE_COLUMN_LEGEND

--- a/utils/poisson_utils/__init__.py
+++ b/utils/poisson_utils/__init__.py
@@ -93,3 +93,7 @@ from .corners import (
 )
 
 from .whoscored_api import get_whoscored_xg, get_whoscored_xg_xga
+from .cross_league import (
+    calculate_cross_league_team_index,
+    CROSS_LEAGUE_COLUMN_LEGEND,
+)

--- a/utils/poisson_utils/cross_league.py
+++ b/utils/poisson_utils/cross_league.py
@@ -1,0 +1,96 @@
+import pandas as pd
+
+
+# Descriptions for metrics returned by ``calculate_cross_league_team_index``.
+CROSS_LEAGUE_COLUMN_LEGEND = {
+    "goals_for_per_match": "Goals scored per match (per 90 minutes)",
+    "goals_against_per_match": "Goals conceded per match",
+    "xg_for_per_match": "Expected goals for per match",
+    "xg_against_per_match": "Expected goals against per match",
+    "shots_for_per_match": "Shots taken per match",
+    "shots_against_per_match": "Shots conceded per match",
+    "xg_ratio_vs_league_avg": "Team xG ratio relative to the average of its league",
+    "xg_ratio_vs_world": "League-strength adjusted xG ratio scaled to world average",
+    "offensive_ratio": "Goals scored per match divided by goals conceded per match",
+    "defensive_ratio": "Expected goals conceded per match divided by expected goals for",
+    "cross_league_index": "Composite strength index for comparing clubs across leagues",
+}
+
+
+def calculate_cross_league_team_index(df: pd.DataFrame, league_ratings: pd.DataFrame) -> pd.DataFrame:
+    """Return league-adjusted team ratings to compare clubs across leagues.
+
+    The resulting DataFrame contains columns described in
+    ``CROSS_LEAGUE_COLUMN_LEGEND``.
+
+    Parameters
+    ----------
+    df: pd.DataFrame
+        Team statistics with columns ``league``, ``team``, ``matches`` and
+        metrics like ``goals_for``, ``goals_against``, ``xg_for``, ``xg_against``
+        (optionally ``shots_for`` and ``shots_against``). Values should be totals
+        across the provided matches.
+    league_ratings: pd.DataFrame
+        Table of league strength ratings with columns ``league`` and ``elo``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Original DataFrame extended with per-match metrics, normalised xG ratio
+        and a ``cross_league_index`` scaled by league strength. Higher values
+        indicate a stronger team relative to world average.
+    """
+    base_metrics = [
+        "goals_for",
+        "goals_against",
+        "xg_for",
+        "xg_against",
+        "shots_for",
+        "shots_against",
+    ]
+
+    df = df.copy()
+    available = [m for m in base_metrics if m in df.columns]
+    if "matches" not in df.columns or df["matches"].eq(0).any():
+        raise ValueError("DataFrame must contain 'matches' column with non-zero values")
+
+    # convert to per-match values (per 90 minutes) and rename columns
+    df[available] = df[available].div(df["matches"], axis=0)
+    rename_map = {
+        "goals_for": "goals_for_per_match",
+        "goals_against": "goals_against_per_match",
+        "xg_for": "xg_for_per_match",
+        "xg_against": "xg_against_per_match",
+        "shots_for": "shots_for_per_match",
+        "shots_against": "shots_against_per_match",
+    }
+    df.rename(columns={k: rename_map[k] for k in available}, inplace=True)
+
+    # xG ratio relative to league average
+    if {"xg_for_per_match", "xg_against_per_match"}.issubset(df.columns):
+        df["_xg_ratio"] = df["xg_for_per_match"] / df["xg_against_per_match"].replace(0, pd.NA)
+        df["_xg_league_avg"] = df.groupby("league")["_xg_ratio"].transform("mean")
+        df["xg_ratio_vs_league_avg"] = df["_xg_ratio"] / df["_xg_league_avg"]
+        df.drop(columns=["_xg_ratio", "_xg_league_avg"], inplace=True)
+    else:
+        df["xg_ratio_vs_league_avg"] = 1.0
+
+    # merge league strength and scale to world average
+    df = df.merge(league_ratings, on="league", how="left")
+    if df["elo"].isna().any():
+        raise ValueError("Missing ELO rating for some leagues")
+    elo_mean = league_ratings["elo"].mean()
+    df["xg_ratio_vs_world"] = df["xg_ratio_vs_league_avg"] * (df["elo"] / elo_mean)
+
+    # simple offensive/defensive ratios
+    df["offensive_ratio"] = (
+        df["goals_for_per_match"] / df["goals_against_per_match"].replace(0, pd.NA)
+    )
+    df["defensive_ratio"] = (
+        df["xg_against_per_match"] / df["xg_for_per_match"].replace(0, pd.NA)
+    )
+
+    df["cross_league_index"] = (
+        df["offensive_ratio"] * (1 / df["defensive_ratio"]) * df["xg_ratio_vs_world"]
+    )
+    return df


### PR DESCRIPTION
## Summary
- Rename cross-league metrics to descriptive `*_per_match` and ratio fields
- Provide `CROSS_LEAGUE_COLUMN_LEGEND` mapping to explain each metric
- Adjust tests for new column names and legend coverage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0ff32707c8329ae5a7fdb55899b3c