### PR TITLE
feat: clarify cross-league ratings section

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,7 +18,7 @@ from sections.match_prediction_section import render_single_match_prediction
 from sections.multi_prediction_section import render_multi_match_predictions
 from sections.team_detail_section import render_team_detail
 from sections.my_bets_section import render_my_bets_section as render_my_bets
-from sections.cross_league_section import render_cross_league_index
+from sections.cross_league_section import render_cross_league_ratings
 
 import urllib.parse
 from utils.poisson_utils import (
@@ -231,7 +231,7 @@ df, season_df, gii_dict, elo_dict = load_and_prepare(league_file)
 # Zachováme kompletní dataset pro historické statistiky (H2H apod.)
 full_df = df.copy()
 
-# Cross-league index for all teams
+# Cross-league ratings for all teams
 cross_league_df = compute_cross_league_index(league_files)
 
 # --- Date range filtr ---
@@ -266,7 +266,7 @@ navigation = st.sidebar.radio(
         "League overview",
         "Match prediction",
         "Multi predictions",
-        "Cross-league index",
+        "Cross-league ratings",
         "My Bets",
     ),
 )
@@ -342,8 +342,8 @@ elif navigation == "Multi predictions":
         league_files,
     )
 
-elif navigation == "Cross-league index":
-    render_cross_league_index(cross_league_df)
+elif navigation == "Cross-league ratings":
+    render_cross_league_ratings(cross_league_df)
 
 elif selected_team:
     render_team_detail(df, season_df, selected_team, league_name, gii_dict)

--- a/sections/cross_league_section.py
+++ b/sections/cross_league_section.py
@@ -1,10 +1,11 @@
 import streamlit as st
 import pandas as pd
 
-def render_cross_league_index(df: pd.DataFrame) -> None:
-    """Display cross-league team index with optional filtering."""
 
-    st.header("🌍 Cross-League Team Index")
+def render_cross_league_ratings(df: pd.DataFrame) -> None:
+    """Display cross-league team ratings with optional filtering."""
+
+    st.header("🌍 Cross-League Team Ratings")
 
     if df.empty:
         st.info("No team data available.")
@@ -19,16 +20,27 @@ def render_cross_league_index(df: pd.DataFrame) -> None:
     if selected_teams:
         filtered = filtered[filtered["team"].isin(selected_teams)]
 
-    display_cols = [
-        "league",
-        "team",
-        "team_index",
-        "xg_vs_world",
-        "off_rating",
-        "def_rating",
-    ]
-    st.dataframe(
-        filtered.sort_values("team_index", ascending=False)[display_cols].reset_index(drop=True),
-        hide_index=True,
-        use_container_width=True,
+    display_cols = {
+        "league": "League",
+        "team": "Team",
+        "team_index": "Team Strength",
+        "xg_vs_world": "xG vs World",
+        "off_rating": "Offensive Rating",
+        "def_rating": "Defensive Rating",
+    }
+    table = (
+        filtered.sort_values("team_index", ascending=False)[display_cols.keys()]
+        .reset_index(drop=True)
+        .rename(columns=display_cols)
+    )
+    st.dataframe(table, hide_index=True, use_container_width=True)
+
+    st.caption(
+        """
+**Legend**
+- **Team Strength** – overall team rating relative to global average.
+- **xG vs World** – expected goals difference against a world-average opponent.
+- **Offensive Rating** – attacking strength (higher is better).
+- **Defensive Rating** – defensive strength (higher is better).
+        """
     )


### PR DESCRIPTION
## Summary
- rename cross-league section to "Cross-league ratings" in navigation
- provide clearer column names with explanatory legend

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a11140efa88329a813685b6600d009