### PR TITLE
Refine cross-league team index with team ELO and xG differential

### DIFF
--- a/tests/test_cross_league_team_index.py
+++ b/tests/test_cross_league_team_index.py
@@ -7,23 +7,33 @@ from utils.poisson_utils import calculate_cross_league_team_index
 def test_cross_league_team_index_basic():
     teams = pd.DataFrame(
         {
-            "league": ["A", "A", "B"],
-            "team": ["A1", "A2", "B1"],
-            "matches": [2, 2, 2],
-            "goals_for": [4, 2, 3],
-            "goals_against": [1, 2, 2],
-            "xg_for": [3.0, 1.0, 2.0],
-            "xg_against": [1.0, 2.0, 1.0],
+            "league": ["A", "A", "B", "B"],
+            "team": ["A1", "A2", "B1", "B2"],
+            "matches": [2, 2, 2, 2],
+            "goals_for": [3, 0, 2, 0],
+            "goals_against": [0, 3, 0, 2],
+            "xg_for": [2.5, 0.7, 1.8, 0.6],
+            "xg_against": [0.5, 1.3, 0.6, 1.4],
         }
     )
     ratings = pd.DataFrame({"league": ["A", "B"], "elo": [1600, 1400]})
+    matches = pd.DataFrame(
+        {
+            "Date": pd.date_range("2021-01-01", periods=4, freq="D"),
+            "league": ["A", "A", "B", "B"],
+            "HomeTeam": ["A1", "A2", "B1", "B2"],
+            "AwayTeam": ["A2", "A1", "B2", "B1"],
+            "FTHG": [2, 0, 1, 0],
+            "FTAG": [0, 1, 0, 1],
+        }
+    )
 
-    result = calculate_cross_league_team_index(teams, ratings)
+    result = calculate_cross_league_team_index(teams, ratings, matches)
 
-    # team_index should rank A1 highest, B1 second, A2 lowest
+    # team_index should rank A1 highest, B1 second, A2 third, B2 last
     ordered = list(result.sort_values("team_index", ascending=False)["team"])
-    assert ordered == ["A1", "B1", "A2"]
+    assert ordered == ["A1", "B1", "A2", "B2"]
 
     # check expected value for A1 approximately
     a1_index = result.loc[result["team"] == "A1", "team_index"].item()
-    assert a1_index == pytest.approx(21.94, rel=1e-2)
+    assert a1_index == pytest.approx(0.91736, rel=1e-3)


### PR DESCRIPTION
## Summary
- incorporate team-level ELO ratings into cross-league index calculations
- normalize expected-goal differential by league and combine with relative team ELO
- update tests for new ELO-based cross-league index

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a189e99f3c83299ce20e9e55bbd2df