### PR TITLE
Integrate schedule strength into cross-league ratings

### DIFF
--- a/tests/test_cross_league_team_index.py
+++ b/tests/test_cross_league_team_index.py
@@ -36,4 +36,4 @@ def test_cross_league_team_index_basic():
 
     # check expected value for A1 approximately
     a1_index = result.loc[result["team"] == "A1", "team_index"].item()
-    assert a1_index == pytest.approx(0.91736, rel=1e-3)
+    assert a1_index == pytest.approx(0.810697, rel=1e-3)


### PR DESCRIPTION
## Summary
- Incorporate strength-of-schedule into cross-league team index calculations
- Import and apply opponent-quality z-scores to adjust the team index
- Update tests for the new schedule strength component

## Testing
- `PYTHONPATH=. pytest tests/test_cross_league_team_index.py -q`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a18bef69fc8329839ee025e41297ce