### PR TITLE
Validate leagues before merging ratings

### DIFF
--- a/utils/poisson_utils/cross_league.py
+++ b/utils/poisson_utils/cross_league.py
@@ -84,6 +84,10 @@ def calculate_cross_league_team_index(
         df["xg_diff_norm"] = 0.0
 
     # merge league strength and scale to world average
+    missing_leagues = set(df["league"].unique()) - set(league_ratings["league"])
+    if missing_leagues:
+        missing = ", ".join(sorted(missing_leagues))
+        raise ValueError(f"Missing league ratings for: {missing}")
     df = df.merge(league_ratings, on="league", how="left")
     if df["elo"].isna().any():
         raise ValueError("Missing ELO rating for some leagues")


### PR DESCRIPTION
## Summary
- ensure all leagues have ratings before merge to prevent missing values
- raise descriptive errors listing missing leagues and handle NaN ratings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a191e57f388329a2d57220af0d4dea