### PR TITLE
Add league quality table to cross-league ratings

### DIFF
--- a/sections/cross_league_section.py
+++ b/sections/cross_league_section.py
@@ -2,7 +2,7 @@ import streamlit as st
 import pandas as pd
 
 
-def render_cross_league_ratings(df: pd.DataFrame) -> None:
+def render_cross_league_ratings(df: pd.DataFrame, league_table: pd.DataFrame) -> None:
     """Display cross-league team ratings with optional filtering."""
 
     st.header("🌍 Cross-League Team Ratings")
@@ -14,11 +14,24 @@ def render_cross_league_ratings(df: pd.DataFrame) -> None:
     leagues = sorted(df["league"].unique())
     selected_leagues = st.multiselect("Leagues", leagues, default=leagues)
     filtered = df[df["league"].isin(selected_leagues)]
+    league_filtered = league_table[league_table["league"].isin(selected_leagues)]
 
     teams = sorted(filtered["team"].unique())
     selected_teams = st.multiselect("Teams", teams)
     if selected_teams:
         filtered = filtered[filtered["team"].isin(selected_teams)]
+
+    league_cols = {
+        "league": "League",
+        "elo": "ELO",
+        "penalty_coef": "Penalty Coef",
+    }
+    league_display = (
+        league_filtered.sort_values("penalty_coef", ascending=False)[league_cols.keys()]
+        .reset_index(drop=True)
+        .rename(columns=league_cols)
+    )
+    st.dataframe(league_display, hide_index=True, use_container_width=True)
 
     display_cols = {
         "league": "League",
@@ -38,6 +51,7 @@ def render_cross_league_ratings(df: pd.DataFrame) -> None:
     st.caption(
         """
 **Legend**
+- **Penalty Coef** – league strength relative to global average; lower values denote weaker leagues and reduce team ratings.
 - **Team Strength** – overall team rating relative to global average.
 - **ELO Adj** – team's ELO rating relative to its league average (1.0 is league mean).
 - **xG Diff Adj** – expected goals differential normalised within its league.

--- a/utils/poisson_utils/cross_league.py
+++ b/utils/poisson_utils/cross_league.py
@@ -11,6 +11,29 @@ from .team_analysis import calculate_strength_of_schedule
 WORLD_ELO_MEAN = 1500
 
 
+def build_league_quality_table(league_ratings: pd.DataFrame) -> pd.DataFrame:
+    """Return league strength table with penalty coefficients.
+
+    Parameters
+    ----------
+    league_ratings : pd.DataFrame
+        Table of league ELO ratings with columns ``league`` and ``elo``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Copy of ``league_ratings`` with an additional ``penalty_coef`` column
+        representing the league's strength relative to the global average. A
+        value below ``1`` denotes a weaker league where team ratings are
+        penalised.
+    """
+    table = league_ratings.copy()
+    if "elo" not in table.columns:
+        raise ValueError("league_ratings must contain 'elo' column")
+    table["penalty_coef"] = table["elo"] / WORLD_ELO_MEAN
+    return table
+
+
 def calculate_cross_league_team_index(
     df: pd.DataFrame,
     league_ratings: pd.DataFrame,


### PR DESCRIPTION
## Summary
- add `build_league_quality_table` helper to compute ELO-based penalty coefficients per league
- display league quality table in cross-league ratings and explain penalty coefficient meaning
- compute and pass league quality table through app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a196bc641083298ff2b68226898195