### PR TITLE
Expose league penalty coefficient in cross-league ratings

### DIFF
--- a/sections/cross_league_section.py
+++ b/sections/cross_league_section.py
@@ -24,10 +24,10 @@ def render_cross_league_ratings(df: pd.DataFrame, league_table: pd.DataFrame) ->
     league_cols = {
         "league": "League",
         "elo": "ELO",
-        "penalty_coef": "Penalty Coef",
+        "league_penalty_coef": "Penalty Coef",
     }
     league_display = (
-        league_filtered.sort_values("penalty_coef", ascending=False)[league_cols.keys()]
+        league_filtered.sort_values("league_penalty_coef", ascending=False)[league_cols.keys()]
         .reset_index(drop=True)
         .rename(columns=league_cols)
     )
@@ -36,6 +36,7 @@ def render_cross_league_ratings(df: pd.DataFrame, league_table: pd.DataFrame) ->
     display_cols = {
         "league": "League",
         "team": "Team",
+        "league_penalty_coef": "Penalty Coef",
         "team_index": "Team Strength",
         "team_elo_rel": "ELO Adj",
         "xg_diff_norm": "xG Diff Adj",

--- a/tests/test_cross_league_team_index.py
+++ b/tests/test_cross_league_team_index.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pytest
 
 from utils.poisson_utils import calculate_cross_league_team_index
+from utils.poisson_utils.cross_league import WORLD_ELO_MEAN
 
 
 @pytest.fixture
@@ -100,6 +101,11 @@ def test_cross_league_team_index_basic():
     a1_def = result.loc[result["team"] == "A1", "def_rating"].item()
     assert a1_off == pytest.approx(0.12, rel=1e-3)
     assert a1_def == pytest.approx(0.095, rel=1e-3)
+
+    # league penalty coefficient should be exposed
+    assert "league_penalty_coef" in result.columns
+    a1_coef = result.loc[result["team"] == "A1", "league_penalty_coef"].item()
+    assert a1_coef == pytest.approx(1600 / WORLD_ELO_MEAN, rel=1e-3)
 
 
 def test_cross_league_team_index_respects_league_strength(sample_european_teams):


### PR DESCRIPTION
## Summary
- rename internal `league_factor` to `league_penalty_coef`
- include `league_penalty_coef` in team and league tables and use it to scale ratings
- show penalty coefficient in cross-league ratings UI and add regression test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1982136008329b5cd8744412e96ab