### PR TITLE
Include cup matches in cross-league calculations

### DIFF
--- a/update_league_penalty_coefficients.py
+++ b/update_league_penalty_coefficients.py
@@ -8,27 +8,42 @@ ROOT = Path(__file__).resolve().parent
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))
 
-from utils.poisson_utils import calculate_elo_ratings
+from utils.poisson_utils import calculate_elo_ratings, load_cup_matches
 from utils.poisson_utils.cross_league import WORLD_ELO_MEAN
 
 
 def main() -> None:
     data_dir = ROOT / "data"
-    rating_rows = []
+
+    match_frames: list[pd.DataFrame] = []
+    team_league_map: dict[str, str] = {}
+
     for csv in sorted(data_dir.glob("*_combined_full_updated.csv")):
         league_code = csv.name.split("_")[0]
         df = pd.read_csv(csv)
-        elo_dict = calculate_elo_ratings(df)
-        avg_elo = sum(elo_dict.values()) / len(elo_dict)
-        rating_rows.append(
-            {
-                "league": league_code,
-                "elo": round(avg_elo, 3),
-                "penalty_coef": round(avg_elo / WORLD_ELO_MEAN, 3),
-            }
-        )
+        match_frames.append(df[["Date", "HomeTeam", "AwayTeam", "FTHG", "FTAG"]])
+        teams = pd.concat([df["HomeTeam"], df["AwayTeam"]]).unique()
+        for team in teams:
+            team_league_map[team] = league_code
+
+    cup_df = load_cup_matches(team_league_map, data_dir)
+    if not cup_df.empty:
+        match_frames.append(cup_df[["Date", "HomeTeam", "AwayTeam", "FTHG", "FTAG"]])
+
+    all_matches = pd.concat(match_frames, ignore_index=True)
+    elo_dict = calculate_elo_ratings(all_matches)
+    elo_df = pd.DataFrame(list(elo_dict.items()), columns=["team", "elo"])
+    elo_df["league"] = elo_df["team"].map(team_league_map)
+    elo_df = elo_df.dropna(subset=["league"])
+
+    rating_rows = (
+        elo_df.groupby("league")["elo"].mean().reset_index()
+    )
+    rating_rows["penalty_coef"] = rating_rows["elo"] / WORLD_ELO_MEAN
+    rating_rows = rating_rows.round({"elo": 3, "penalty_coef": 3})
+
     out_path = data_dir / "league_penalty_coefficients.csv"
-    pd.DataFrame(rating_rows).sort_values("league").to_csv(out_path, index=False)
+    rating_rows.sort_values("league").to_csv(out_path, index=False)
     print(f"Saved {out_path}")
 
 

--- a/utils/poisson_utils/__init__.py
+++ b/utils/poisson_utils/__init__.py
@@ -5,6 +5,7 @@ from .data import (
     load_data,
     detect_current_season,
     get_last_n_matches,
+    load_cup_matches,
 )
 
 from .stats import (


### PR DESCRIPTION
## Summary
- Add `load_cup_matches` helper to read cup CSVs, map teams to domestic leagues, and return match data.
- Extend cross-league index computation to map team leagues and include cup fixtures when building the match set.
- Rework league penalty coefficient update script to compute ELO averages using both league and cup matches.

## Testing
- `PYTHONPATH=. pytest tests/test_cross_league_team_index.py tests/test_multi_prediction_cache.py tests/test_load_data_parquet.py tests/test_data_columns.py`


------
https://chatgpt.com/codex/tasks/task_e_68a20b7be9dc8329ad0409d641d7ed0b