### PR TITLE
Add UEFA cup predictions section

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,6 +19,7 @@ from sections.multi_prediction_section import render_multi_match_predictions
 from sections.team_detail_section import render_team_detail
 from sections.my_bets_section import render_my_bets_section as render_my_bets
 from sections.cross_league_section import render_cross_league_ratings
+from sections.uefa_cup_section import render_uefa_cup_predictions
 
 import urllib.parse
 
@@ -308,6 +309,7 @@ navigation = st.sidebar.radio(
         "Match prediction",
         "Multi predictions",
         "Cross-league ratings",
+        "UEFA Cups",
         "My Bets",
     ),
 )
@@ -385,6 +387,9 @@ elif navigation == "Multi predictions":
 
 elif navigation == "Cross-league ratings":
     render_cross_league_ratings(cross_league_df, league_quality_df)
+
+elif navigation == "UEFA Cups":
+    render_uefa_cup_predictions(cross_league_df, ROOT / "data")
 
 elif selected_team:
     render_team_detail(df, season_df, selected_team, league_name, gii_dict)

--- a/sections/uefa_cup_section.py
+++ b/sections/uefa_cup_section.py
@@ -1,0 +1,92 @@
+import streamlit as st
+import pandas as pd
+from pathlib import Path
+
+from utils.poisson_utils.cup_predictions import predict_cup_match
+from utils.poisson_utils.data import prepare_df
+
+CUP_FILES = {
+    "Champions League": "CL_combined_full.csv",
+    "Europa League": "EL_combined_full.csv",
+    "Conference League": "ECL_combined_full.csv",
+}
+
+
+@st.cache_data
+def load_upcoming_cup_fixtures(data_dir: str | Path = "data") -> pd.DataFrame:
+    """Return upcoming fixtures from predefined UEFA cup CSV files.
+
+    Parameters
+    ----------
+    data_dir : str or Path, optional
+        Directory containing the cup CSV files. Defaults to ``"data"``.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with columns ``Date``, ``Competition``, ``HomeTeam`` and
+        ``AwayTeam`` for matches where scores are missing.
+    """
+
+    data_dir = Path(data_dir)
+    frames: list[pd.DataFrame] = []
+    for competition, filename in CUP_FILES.items():
+        path = data_dir / filename
+        if not path.exists():
+            continue
+        try:
+            df = pd.read_csv(path)
+        except Exception:
+            continue
+        df = prepare_df(df)
+        if {"FTHG", "FTAG"}.issubset(df.columns):
+            df = df[df["FTHG"].isna() & df["FTAG"].isna()]
+        else:
+            df = df.iloc[0:0]
+        if df.empty:
+            continue
+        df = df[["Date", "HomeTeam", "AwayTeam"]].copy()
+        df["Competition"] = competition
+        frames.append(df)
+
+    if not frames:
+        return pd.DataFrame(columns=["Date", "Competition", "HomeTeam", "AwayTeam"])
+
+    return pd.concat(frames, ignore_index=True).sort_values("Date")
+
+
+def render_uefa_cup_predictions(cross_league_df: pd.DataFrame, data_dir: str | Path = "data") -> None:
+    """Render table of predicted outcomes for upcoming UEFA cup fixtures."""
+
+    st.header("🏆 UEFA Cup Predictions")
+    fixtures = load_upcoming_cup_fixtures(data_dir)
+    if fixtures.empty:
+        st.info("No upcoming fixtures found for the Champions League, Europa League or Conference League.")
+        return
+
+    rows: list[dict] = []
+    for row in fixtures.itertuples(index=False):
+        try:
+            preds = predict_cup_match(row.HomeTeam, row.AwayTeam, cross_league_df)
+        except KeyError:
+            continue
+        rows.append(
+            {
+                "Date": row.Date.date(),
+                "Competition": row.Competition,
+                "Home": row.HomeTeam,
+                "Away": row.AwayTeam,
+                "Home xG": preds["home_exp_goals"],
+                "Away xG": preds["away_exp_goals"],
+                "Home Win %": preds["home_win_pct"],
+                "Draw %": preds["draw_pct"],
+                "Away Win %": preds["away_win_pct"],
+            }
+        )
+
+    if not rows:
+        st.info("No predictions available for the loaded fixtures.")
+        return
+
+    table = pd.DataFrame(rows)
+    st.dataframe(table, hide_index=True, use_container_width=True)


### PR DESCRIPTION
## Summary
- add Streamlit section that loads UEFA cup fixtures and displays Poisson-based predictions
- integrate navigation and routing for new cup predictions page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2162ad744832998307047c7dea01b