### PR TITLE
Add tests for cup match predictions and fix win probability orientation

### DIFF
--- a/tests/test_cup_predictions.py
+++ b/tests/test_cup_predictions.py
@@ -1,0 +1,45 @@
+import pandas as pd
+import pytest
+
+from utils.poisson_utils import predict_cup_match
+from utils.poisson_utils import cup_predictions
+
+
+@pytest.fixture
+def cross_league_df():
+    return pd.DataFrame(
+        {
+            "team": ["CL Team", "EL Team", "ECL Team"],
+            "league": ["CL", "EL", "ECL"],
+            "team_index": [1.2, 1.0, 0.8],
+        }
+    )
+
+
+def test_probabilities_sum_and_rating_effect(cross_league_df):
+    preds = predict_cup_match("CL Team", "ECL Team", cross_league_df)
+    total = preds["home_win_pct"] + preds["draw_pct"] + preds["away_win_pct"]
+    assert total == pytest.approx(100, abs=0.5)
+    assert preds["home_win_pct"] > preds["away_win_pct"]
+
+    reverse = predict_cup_match("ECL Team", "CL Team", cross_league_df)
+    total_rev = reverse["home_win_pct"] + reverse["draw_pct"] + reverse["away_win_pct"]
+    assert total_rev == pytest.approx(100, abs=0.5)
+    assert reverse["away_win_pct"] > reverse["home_win_pct"]
+
+
+def test_neutral_venue_identical_ratings(monkeypatch):
+    df = pd.DataFrame(
+        {
+            "team": ["Team A", "Team B"],
+            "league": ["CL", "EL"],
+            "team_index": [1.0, 1.0],
+        }
+    )
+
+    monkeypatch.setattr(cup_predictions, "HOME_ADVANTAGE", 0)
+
+    preds = predict_cup_match("Team A", "Team B", df)
+    total = preds["home_win_pct"] + preds["draw_pct"] + preds["away_win_pct"]
+    assert total == pytest.approx(100, abs=0.5)
+    assert preds["home_win_pct"] == pytest.approx(preds["away_win_pct"], abs=1e-2)

--- a/utils/poisson_utils/cup_predictions.py
+++ b/utils/poisson_utils/cup_predictions.py
@@ -111,9 +111,12 @@ def predict_cup_match(home_team: str, away_team: str, cross_league_df: pd.DataFr
     away_exp = max(away_exp, 0.01)
 
     matrix = poisson_prediction(home_exp, away_exp, max_goals=MAX_GOALS)
-    home_win = float(np.triu(matrix, 1).sum())
+    # Lower triangle (excluding diagonal) represents home team wins when rows
+    # correspond to home goals and columns to away goals.
+    home_win = float(np.tril(matrix, -1).sum())
     draw = float(np.trace(matrix))
-    away_win = float(np.tril(matrix, -1).sum())
+    # Upper triangle (excluding diagonal) captures away team wins.
+    away_win = float(np.triu(matrix, 1).sum())
 
     return {
         "home_exp_goals": round(home_exp, 2),


### PR DESCRIPTION
## Summary
- add unit tests for inter-league cup match predictions
- fix `predict_cup_match` win probability orientation
- cover neutral venue and identical rating edge cases

## Testing
- `PYTHONPATH=. pytest tests/test_cup_predictions.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2174956988329a1602ee9bb27fe08