### PR TITLE
Add workflow to refresh match data

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -1,0 +1,32 @@
+name: Refresh match data
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Configure git
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      - name: Update league data
+        run: python update_league_data.py
+      - name: Commit and push changes
+        run: python commit_and_push.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to periodically update league data from football-data.co.uk and commit results

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a219656cbc8329ba8b4fdc8f625a37