### PR TITLE
Add Understat xG fetcher with caching and tests

### DIFF
--- a/tests/xg_sources/test_understat.py
+++ b/tests/xg_sources/test_understat.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from utils.poisson_utils.xg_sources import understat as understat_module
+from utils.poisson_utils.xg_sources.understat import fetch_understat_team_xg
+
+
+FIXTURE = Path(__file__).with_name("understat_team_fixture.html")
+
+
+def _load_fixture() -> str:
+    return FIXTURE.read_text(encoding="utf-8")
+
+
+def test_fetch_understat_team_xg(monkeypatch, tmp_path):
+    # isolate cache file
+    cache_file = tmp_path / "understat_xg_cache.json"
+    monkeypatch.setattr(understat_module, "CACHE_FILE", cache_file)
+
+    html = _load_fixture()
+
+    calls = {"count": 0}
+
+    def fake_get(url, headers=None, timeout=None):
+        calls["count"] += 1
+        class Resp:
+            status_code = 200
+            text = html
+        return Resp()
+
+    monkeypatch.setattr(understat_module.requests, "get", fake_get)
+
+    data = fetch_understat_team_xg("TestTeam", "2020")
+    assert data is not None
+    assert data["xg"] == pytest.approx(1.1)
+    assert data["xga"] == pytest.approx(0.8)
+    assert cache_file.exists()
+    assert calls["count"] == 1
+
+    # subsequent call uses cache, no network
+    def fail_get(*args, **kwargs):
+        raise AssertionError("network call should not happen")
+
+    monkeypatch.setattr(understat_module.requests, "get", fail_get)
+    data_cached = fetch_understat_team_xg("TestTeam", "2020")
+    assert data_cached == data
+    assert calls["count"] == 1

--- a/tests/xg_sources/understat_team_fixture.html
+++ b/tests/xg_sources/understat_team_fixture.html
@@ -1,0 +1,8 @@
+<html>
+<head><title>Fixture</title></head>
+<body>
+<script>
+var shotsData = JSON.parse('{"1": {"h": [{"xG": "1.0", "h_team": "TestTeam", "a_team": "Opp1"}, {"xG": "0.5", "h_team": "TestTeam", "a_team": "Opp1"}], "a": [{"xG": "0.3", "h_team": "TestTeam", "a_team": "Opp1"}]}, "2": {"h": [{"xG": "1.2", "h_team": "Opp2", "a_team": "TestTeam"}, {"xG": "0.1", "h_team": "Opp2", "a_team": "TestTeam"}], "a": [{"xG": "0.7", "h_team": "Opp2", "a_team": "TestTeam"}]}}');
+</script>
+</body>
+</html>

--- a/utils/poisson_utils/xg_sources/understat.py
+++ b/utils/poisson_utils/xg_sources/understat.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Dict, Optional
+
+import requests
+
+CACHE_FILE = Path(__file__).with_name("understat_xg_cache.json")
+
+
+def _load_cache() -> Dict[str, Dict[str, float]]:
+    if CACHE_FILE.exists():
+        try:
+            with CACHE_FILE.open("r", encoding="utf-8") as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def _save_cache(cache: Dict[str, Dict[str, float]]) -> None:
+    with CACHE_FILE.open("w", encoding="utf-8") as f:
+        json.dump(cache, f)
+
+
+def fetch_understat_team_xg(team: str, season: str) -> Optional[Dict[str, float]]:
+    """Fetch average xG and xGA per match for a team and season.
+
+    Returns ``None`` if the page cannot be retrieved, rate limited or the schema
+    is not as expected.
+    """
+    cache = _load_cache()
+    key = f"{season}|{team}"
+    if key in cache:
+        return cache[key]
+
+    url = f"https://understat.com/team/{team}/{season}"
+    try:
+        resp = requests.get(url, headers={"User-Agent": "Mozilla/5.0"}, timeout=10)
+    except requests.RequestException:
+        return None
+    if resp.status_code != 200:
+        return None
+
+    html = resp.text
+    match = re.search(r"shotsData\s*=\s*JSON.parse\('([^']+)'\)", html)
+    if not match:
+        return None
+
+    raw_json = match.group(1)
+    try:
+        decoded = raw_json.encode("utf-8").decode("unicode_escape")
+        shots_data = json.loads(decoded)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+
+    total_xg = 0.0
+    total_xga = 0.0
+    matches = 0
+
+    try:
+        items = shots_data.values() if isinstance(shots_data, dict) else shots_data
+        for entry in items:
+            matches += 1
+            for shot in entry.get("h", []):
+                xg = float(shot.get("xG", 0) or 0)
+                if shot.get("h_team") == team:
+                    total_xg += xg
+                else:
+                    total_xga += xg
+            for shot in entry.get("a", []):
+                xg = float(shot.get("xG", 0) or 0)
+                if shot.get("a_team") == team:
+                    total_xg += xg
+                else:
+                    total_xga += xg
+    except Exception:
+        return None
+
+    if matches == 0:
+        return None
+
+    result = {"xg": total_xg / matches, "xga": total_xga / matches}
+    cache[key] = result
+    _save_cache(cache)
+    return result
+
+
+def get_team_xg_xga(team: str, season: str) -> Dict[str, float]:
+    return fetch_understat_team_xg(team, season) or {}


### PR DESCRIPTION
## Summary
- implement Understat xG scraper with caching and graceful error handling
- add fixtures and unit tests for Understat xG parsing and caching

## Testing
- `pytest tests/xg_sources/test_understat.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a356502c6c8329a669aea6c39da175