### PR TITLE
Add FBRef xG source with caching and tests

### DIFF
--- a/tests/xg_sources/fbref_team_stats.html
+++ b/tests/xg_sources/fbref_team_stats.html
@@ -1,0 +1,16 @@
+<table id="stats">
+  <tbody>
+    <tr>
+      <th data-stat="team"><a>Arsenal</a></th>
+      <td data-stat="games">38</td>
+      <td data-stat="xg_for">70</td>
+      <td data-stat="xg_against">40</td>
+    </tr>
+    <tr>
+      <th data-stat="team"><a>Another</a></th>
+      <td data-stat="games">38</td>
+      <td data-stat="xg_for">50</td>
+      <td data-stat="xg_against">60</td>
+    </tr>
+  </tbody>
+</table>

--- a/tests/xg_sources/test_fbref.py
+++ b/tests/xg_sources/test_fbref.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from utils.poisson_utils.xg_sources import fbref as fbref_module
+from utils.poisson_utils.xg_sources.fbref import fetch_fbref_team_xg
+
+FIXTURE = Path(__file__).with_name("fbref_team_stats.html")
+
+
+def _load_fixture() -> str:
+    return FIXTURE.read_text(encoding="utf-8")
+
+
+def test_fetch_fbref_team_xg(monkeypatch, tmp_path):
+    cache_file = tmp_path / "fbref_xg_cache.json"
+    monkeypatch.setattr(fbref_module, "CACHE_FILE", cache_file)
+
+    html = _load_fixture()
+    calls = {"count": 0}
+
+    class Resp:
+        status_code = 200
+        text = html
+
+    def fake_get(url, headers=None, timeout=None):
+        calls["count"] += 1
+        return Resp()
+
+    monkeypatch.setattr(fbref_module.requests, "get", fake_get)
+
+    class FakeRobot:
+        def set_url(self, url):
+            pass
+        def read(self):
+            pass
+        def can_fetch(self, ua, url):
+            return True
+
+    monkeypatch.setattr(fbref_module.robotparser, "RobotFileParser", FakeRobot)
+
+    data = fetch_fbref_team_xg("Arsenal", "2023-2024", "9")
+    assert data is not None
+    assert data["xg"] == pytest.approx(70 / 38)
+    assert data["xga"] == pytest.approx(40 / 38)
+    assert cache_file.exists()
+    assert calls["count"] == 1
+
+    def fail_get(*args, **kwargs):
+        raise AssertionError("network call should not happen")
+
+    monkeypatch.setattr(fbref_module.requests, "get", fail_get)
+    data_cached = fetch_fbref_team_xg("Arsenal", "2023-2024", "9")
+    assert data_cached == data
+    assert calls["count"] == 1

--- a/utils/poisson_utils/xg_sources/fbref.py
+++ b/utils/poisson_utils/xg_sources/fbref.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Optional
+
+import requests
+from bs4 import BeautifulSoup
+from urllib import robotparser
+
+CACHE_FILE = Path(__file__).with_name("fbref_xg_cache.json")
+
+
+def _load_cache() -> Dict[str, Dict[str, float]]:
+    if CACHE_FILE.exists():
+        try:
+            with CACHE_FILE.open("r", encoding="utf-8") as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def _save_cache(cache: Dict[str, Dict[str, float]]) -> None:
+    with CACHE_FILE.open("w", encoding="utf-8") as f:
+        json.dump(cache, f)
+
+
+def _parse_float(text: str) -> float:
+    return float(text.replace(",", "").strip())
+
+
+def fetch_fbref_team_xg(team: str, season: str, league: str) -> Optional[Dict[str, float]]:
+    """Fetch average xG and xGA per match for a team from FBRef.
+
+    Parameters
+    ----------
+    team: str
+        Team name as displayed on FBRef.
+    season: str
+        Season identifier, e.g. ``"2023-2024"``.
+    league: str
+        League identifier used by FBRef (e.g. ``"9"`` for Premier League).
+
+    Returns
+    -------
+    Optional[Dict[str, float]]
+        Dictionary with keys ``"xg"`` and ``"xga"`` containing per-match
+        expected goals for and against. ``None`` is returned on network
+        failures or if the page cannot be retrieved. Parsing problems raise
+        ``ValueError``.
+    """
+    cache = _load_cache()
+    key = f"{season}|{league}|{team}"
+    if key in cache:
+        return cache[key]
+
+    path = f"/en/comps/{league}/{season}/stats"
+    url = f"https://fbref.com{path}"
+
+    rp = robotparser.RobotFileParser()
+    rp.set_url("https://fbref.com/robots.txt")
+    try:
+        rp.read()
+    except Exception:
+        return None
+    if not rp.can_fetch("*", path):
+        raise RuntimeError("Fetching disallowed by robots.txt")
+
+    try:
+        resp = requests.get(url, headers={"User-Agent": "Mozilla/5.0"}, timeout=10)
+    except requests.RequestException:
+        return None
+    if resp.status_code != 200:
+        return None
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+    row = None
+    for th in soup.find_all("th", {"data-stat": "team"}):
+        if th.get_text(strip=True) == team:
+            row = th.parent
+            break
+    if row is None:
+        raise ValueError("team row not found")
+
+    try:
+        games = _parse_float(row.find("td", {"data-stat": "games"}).get_text())
+        xg_total = _parse_float(row.find("td", {"data-stat": "xg_for"}).get_text())
+        xga_total = _parse_float(row.find("td", {"data-stat": "xg_against"}).get_text())
+    except Exception as exc:
+        raise ValueError("required columns missing") from exc
+    if games == 0:
+        raise ValueError("games value is zero")
+
+    result = {"xg": xg_total / games, "xga": xga_total / games}
+    cache[key] = result
+    _save_cache(cache)
+    return result
+
+
+def get_team_xg_xga(team: str, season: str, league: Optional[str] = None) -> Dict[str, float]:
+    if league is None:
+        return {}
+    return fetch_fbref_team_xg(team, season, league) or {}


### PR DESCRIPTION
## Summary
- implement `fetch_fbref_team_xg` for FBRef xG data with caching and robots.txt checks
- add unit test using sample HTML fixture

## Testing
- `pytest tests/xg_sources/test_fbref.py -q` *(fails: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68a360070c1c83299fde6ca5a56cda6f