### PR TITLE
Add pseudo xG source with league dataframe fallback

### DIFF
--- a/sections/match_prediction_section.py
+++ b/sections/match_prediction_section.py
@@ -32,7 +32,6 @@ from utils.poisson_utils import (
     expected_corners,
     poisson_corner_matrix,
     corner_over_under_prob,
-    calculate_team_pseudo_xg,
     detect_current_season,
     get_team_xg_xga,
 )
@@ -86,9 +85,6 @@ def get_cached_match_inputs(df_hash,df, home_team, away_team, elo_dict):
         "xpoints": xpoints
     }
 @st.cache_data
-def cache_team_pseudo_xg_xga(season_df):
-    return calculate_team_pseudo_xg(season_df)
-@st.cache_data
 def get_cached_tempo(df_hash, df, team, opponent_elo, is_home, elo_dict):
     return calculate_match_tempo(df, team, opponent_elo, is_home, elo_dict)
 
@@ -111,26 +107,13 @@ def compute_match_inputs(
     match_data = get_cached_match_inputs(df_hash, df, home_team, away_team, elo_dict)
     season_start = detect_current_season(season_df, prepared=True)[1]
     season = str(season_start.year)
-    ws_home = get_team_xg_xga(home_team, season)
-    ws_away = get_team_xg_xga(away_team, season)
-
-    pseudo_dict = cache_team_pseudo_xg_xga(season_df)
-    pseudo_home = pseudo_dict.get(home_team, {"xg": 0.0, "xga": 0.0})
-    pseudo_away = pseudo_dict.get(away_team, {"xg": 0.0, "xga": 0.0})
+    ws_home = get_team_xg_xga(home_team, season, season_df)
+    ws_away = get_team_xg_xga(away_team, season, season_df)
 
     xg_home = ws_home.get("xg", float("nan"))
     xga_home = ws_home.get("xga", float("nan"))
     xg_away = ws_away.get("xg", float("nan"))
     xga_away = ws_away.get("xga", float("nan"))
-
-    if np.isnan(xg_home):
-        xg_home = pseudo_home["xg"]
-    if np.isnan(xga_home):
-        xga_home = pseudo_home["xga"]
-    if np.isnan(xg_away):
-        xg_away = pseudo_away["xg"]
-    if np.isnan(xga_away):
-        xga_away = pseudo_away["xga"]
 
     corner_home, corner_away = expected_corners(df, home_team, away_team)
 

--- a/sections/overview_section.py
+++ b/sections/overview_section.py
@@ -5,7 +5,6 @@ from utils.poisson_utils import (
     calculate_form_emojis,
     calculate_expected_and_actual_points,
     aggregate_team_stats,
-    calculate_team_pseudo_xg,
     add_btts_column,
     calculate_conceded_goals,
     calculate_recent_team_form,
@@ -46,7 +45,6 @@ def compute_league_summary(season_df, gii_dict, elo_dict):
         .round(0)
     )
     btts = season_df.groupby("HomeTeam")["BTTS"].mean().mul(100).round(0)
-    pseudo_dict = calculate_team_pseudo_xg(season_df)
     sos_dict = calculate_strength_of_schedule(season_df, metric="elo")
 
     trends = []
@@ -63,14 +61,9 @@ def compute_league_summary(season_df, gii_dict, elo_dict):
         avg_goals_all.append(round(avg_goals_per_match, 1))
         score_var.append(round(score_variance, 1))
 
-        ws_stats = get_team_xg_xga(team, season)
-        pseudo_stats = pseudo_dict.get(team, {})
+        ws_stats = get_team_xg_xga(team, season, season_df)
         team_xg = ws_stats.get("xg")
         team_xga = ws_stats.get("xga")
-        if pd.isna(team_xg):
-            team_xg = pseudo_stats.get("xg", 0)
-        if pd.isna(team_xga):
-            team_xga = pseudo_stats.get("xga", 0)
         xg_vals.append(round(team_xg, 2))
         xga_vals.append(round(team_xga, 2))
 

--- a/sections/team_detail_section.py
+++ b/sections/team_detail_section.py
@@ -9,7 +9,7 @@ import plotly.graph_objects as go
 from utils.responsive import responsive_columns
 from utils.poisson_utils import (
     elo_history, calculate_form_emojis, calculate_expected_and_actual_points,
-    aggregate_team_stats, calculate_team_pseudo_xg, detect_current_season,
+    aggregate_team_stats, detect_current_season,
     get_team_xg_xga, calculate_conceded_goals, calculate_recent_team_form,
     calculate_elo_changes, calculate_team_styles,
     intensity_score_to_emoji, compute_score_stats, compute_form_trend,
@@ -220,15 +220,10 @@ def render_team_detail(
     )
 
     # Sezónní xG a xGA – primárně z WhoScored, fallback na pseudo-xG
-    ws_stats = get_team_xg_xga(team, season)
-    pseudo_stats = calculate_team_pseudo_xg(season_df).get(team, {})
+    ws_stats = get_team_xg_xga(team, season, season_df)
 
     team_xg = ws_stats.get("xg", np.nan)
     team_xga = ws_stats.get("xga", np.nan)
-    if np.isnan(team_xg):
-        team_xg = pseudo_stats.get("xg", 0)
-    if np.isnan(team_xga):
-        team_xga = pseudo_stats.get("xga", 0)
 
     col_xg, col_xga = st.columns(2)
     col_xg.metric("Sezónní xG", f"{team_xg:.1f}")

--- a/tests/xg_sources/test_pseudo.py
+++ b/tests/xg_sources/test_pseudo.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import sys
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from utils.poisson_utils.xg_sources.pseudo import fetch_pseudo_xg
+
+
+def test_fetch_pseudo_xg_structure():
+    df = pd.DataFrame(
+        {
+            "HomeTeam": ["A", "B"],
+            "AwayTeam": ["B", "A"],
+            "HS": [10, 8],
+            "HST": [5, 4],
+            "AS": [8, 10],
+            "AST": [4, 5],
+            "FTHG": [1, 2],
+            "FTAG": [0, 1],
+        }
+    )
+
+    result = fetch_pseudo_xg("A", df)
+    assert set(result.keys()) == {"xg", "xga"}
+    assert isinstance(result["xg"], float)
+    assert isinstance(result["xga"], float)

--- a/utils/poisson_utils/team_analysis.py
+++ b/utils/poisson_utils/team_analysis.py
@@ -6,7 +6,6 @@ import streamlit as st
 from .data import prepare_df, get_last_n_matches, detect_current_season
 from .stats import calculate_points
 from .prediction import poisson_over25_probability, expected_goals_vs_similar_elo_weighted
-from .xg import calculate_team_pseudo_xg
 from .xg_sources import get_team_xg_xga
 from utils.utils_warnings import detect_overperformance_and_momentum
 
@@ -906,7 +905,6 @@ def render_team_comparison_section(
 def generate_team_comparison(df: pd.DataFrame, team1: str, team2: str) -> pd.DataFrame:
     season_start = detect_current_season(df, prepared=True)[1]
     season = str(season_start.year)
-    xg_dict = calculate_team_pseudo_xg(df)
 
     def team_stats(df, team):
         home = df[df['HomeTeam'] == team]
@@ -930,11 +928,9 @@ def generate_team_comparison(df: pd.DataFrame, team1: str, team2: str) -> pd.Dat
         accuracy = shots_on_target / shots if shots else 0
         conversion = goals / shots if shots else 0
 
-        ws_stats = get_team_xg_xga(team, season)
-        ws_xg = ws_stats.get("xg")
-        ws_xga = ws_stats.get("xga")
-        xg = ws_xg if not np.isnan(ws_xg) else xg_dict.get(team, {}).get("xg", np.nan)
-        xga = ws_xga if not np.isnan(ws_xga) else xg_dict.get(team, {}).get("xga", np.nan)
+        ws_stats = get_team_xg_xga(team, season, df)
+        xg = ws_stats.get("xg", np.nan)
+        xga = ws_stats.get("xga", np.nan)
 
         clean_sheets = 0
         total_matches = 0

--- a/utils/poisson_utils/xg_sources/__init__.py
+++ b/utils/poisson_utils/xg_sources/__init__.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import json
 from importlib import import_module
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any, Dict, Optional
+
+import pandas as pd
 
 CACHE_FILE = Path(__file__).with_name("xg_cache.json")
 
@@ -23,15 +25,18 @@ def _save_cache(cache: Dict[str, Dict[str, float]]) -> None:
         json.dump(cache, f)
 
 
-def get_team_xg_xga(team: str, season: str) -> Dict[str, Any]:
+def get_team_xg_xga(
+    team: str, season: str, league_df: Optional[pd.DataFrame] = None
+) -> Dict[str, Any]:
     """Return team xG and xGA for a season from available providers.
 
-    Providers are queried in order: ``understat``, ``fbref``, ``pseudo``. The
-    first provider returning both metrics is used. Results are cached on disk to
-    avoid repeated network calls.
+    Providers are queried in order: ``understat`` and ``fbref``.  If both
+    fail and ``league_df`` is provided, pseudo-xG values computed from the
+    dataframe are used. Results are cached on disk to avoid repeated network
+    calls.
     """
     cache = _load_cache()
-    for source in ("understat", "fbref", "pseudo"):
+    for source in ("understat", "fbref"):
         key = f"{season}|{team}|{source}"
         if key in cache:
             data = cache[key]
@@ -49,4 +54,23 @@ def get_team_xg_xga(team: str, season: str) -> Dict[str, Any]:
             cache[key] = {"xg": data["xg"], "xga": data["xga"]}
             _save_cache(cache)
             return {"xg": data["xg"], "xga": data["xga"], "source": source}
+
+    if league_df is not None:
+        source = "pseudo"
+        key = f"{season}|{team}|{source}"
+        if key in cache:
+            data = cache[key]
+            if "xg" in data and "xga" in data:
+                return {**data, "source": source}
+        try:
+            from .pseudo import fetch_pseudo_xg
+
+            data = fetch_pseudo_xg(team, league_df)
+        except Exception:
+            data = {}
+        if isinstance(data, dict) and "xg" in data and "xga" in data:
+            cache[key] = {"xg": data["xg"], "xga": data["xga"]}
+            _save_cache(cache)
+            return {"xg": data["xg"], "xga": data["xga"], "source": source}
+
     return {"xg": float("nan"), "xga": float("nan"), "source": None}

--- a/utils/poisson_utils/xg_sources/pseudo.py
+++ b/utils/poisson_utils/xg_sources/pseudo.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+import pandas as pd
+
+from ..xg import calculate_team_pseudo_xg
+
+
+def fetch_pseudo_xg(team: str, df: pd.DataFrame) -> Dict[str, float]:
+    """Compute pseudo xG and xGA for ``team`` using ``df`` league data."""
+    stats = calculate_team_pseudo_xg(df)
+    return stats.get(team, {})
+
+
+def get_team_xg_xga(team: str, season: str, df: Optional[pd.DataFrame] = None) -> Dict[str, float]:
+    """Return pseudo-xG metrics for compatibility with xg_sources."""
+    if df is None:
+        return {}
+    return fetch_pseudo_xg(team, df)


### PR DESCRIPTION
## Summary
- add pseudo xG source that wraps `calculate_team_pseudo_xg`
- allow `get_team_xg_xga` to accept league DataFrame and use pseudo-xG if other sources fail
- update sections and analysis utilities to pass league data
- add tests for pseudo xG provider

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4')*
- `pytest tests/xg_sources/test_pseudo.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3613604d8832987ec65020f42bec0