### PR TITLE
Add xG-based match predictions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ matplotlib
 seaborn
 plotly
 XlsxWriter>=3.0.0
+openpyxl
 
 requests
 beautifulsoup4


### PR DESCRIPTION
## Summary
- cache loader for upcoming xG data and helper utilities
- generate Poisson probabilities from xG numbers
- integrate xG-based prediction block into match view with value vs odds
- include openpyxl dependency for Excel reading

## Testing
- `pip install openpyxl` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4a7d62c2883298dac99d255a41276