### PR TITLE
Ensure refresh workflow can push updates

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 6 * * *'
 
+permissions:
+  contents: write
+
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- allow GitHub Actions to push changes by granting `contents: write` permission in refresh workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4bdfa34ec8329a264fac7c6d9436e