### PR TITLE
Add GitHub Actions workflow for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Run tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      FOOTBALL_DATA_TOKEN: ${{ secrets.FOOTBALL_DATA_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          pytest


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run pytest with FOOTBALL_DATA_TOKEN

## Testing
- `pytest tests/test_football_data_api.py -q` (skipped: FOOTBALL_DATA_TOKEN not set)


------
https://chatgpt.com/codex/tasks/task_e_68a5fa3928548329827f29f4c261dc62