### PR TITLE
Ensure caches invalidate when league files change

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,5 @@
+__doc__ = None  # prevent accidental module docstring rendering in Streamlit
+
 import time
 import sys
 import os
@@ -95,6 +97,8 @@ with st.sidebar.expander("🔧 Správa dat"):
     if st.button("🔄 Aktualizovat data z webu"):
         with st.spinner("Stahuji a porovnávám data..."):
             logs = update_all_leagues()
+            # clear cached data so modified files are re-read
+            st.cache_data.clear()
             # signalizace pro re-load cache
             if "reload_flag" in st.session_state:
                 del st.session_state["reload_flag"]
@@ -127,7 +131,19 @@ league_file = league_files[league_name]
 
 # --- Načtení a příprava dat ---
 @st.cache_data(show_spinner=False)
-def load_and_prepare(file_path: str):
+def load_and_prepare(file_path: str, mtime: float):
+    """Load league data and compute derived statistics.
+
+    Parameters
+    ----------
+    file_path:
+        Path to the league CSV file.
+    mtime:
+        Last modification timestamp of ``file_path``.  The value itself is not
+        used inside the function but ensures the Streamlit cache is invalidated
+        whenever the underlying data file changes.
+    """
+
     df = load_data(file_path)
     validate_dataset(df)
 
@@ -146,8 +162,19 @@ def load_and_prepare(file_path: str):
 
 
 @st.cache_data(show_spinner=False)
-def compute_cross_league_index(files: dict) -> tuple[pd.DataFrame, pd.DataFrame]:
+def compute_cross_league_index(
+    files: dict, mtimes: dict
+) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Compute cross-league team index for all leagues in ``files``.
+
+    Parameters
+    ----------
+    files:
+        Mapping of league names to their CSV paths.
+    mtimes:
+        Mapping of league names to the last modification timestamp of the
+        corresponding CSV file.  Only used so Streamlit's cache depends on the
+        file contents.
 
     Returns
     -------
@@ -269,12 +296,17 @@ if st.session_state.get("reload_flag"):
     st.cache_data.clear()
     del st.session_state["reload_flag"]
 
-df, season_df, gii_dict, elo_dict = load_and_prepare(league_file)
+df, season_df, gii_dict, elo_dict = load_and_prepare(
+    league_file, os.path.getmtime(league_file)
+)
 # Zachováme kompletní dataset pro historické statistiky (H2H apod.)
 full_df = df.copy()
 
 # Cross-league ratings for all teams
-cross_league_df, league_quality_df = compute_cross_league_index(league_files)
+league_mtimes = {name: os.path.getmtime(path) for name, path in league_files.items()}
+cross_league_df, league_quality_df = compute_cross_league_index(
+    league_files, league_mtimes
+)
 
 # --- Date range filtr ---
 overall_start = df["Date"].min().date()


### PR DESCRIPTION
## Summary
- Include file modification timestamps in `load_and_prepare` and `compute_cross_league_index` cache keys.
- Pass `os.path.getmtime` when loading league data and computing cross-league indices.
- Clear Streamlit caches after data updates to avoid stale cached content.
- Prevent accidental module docstring text from appearing in the UI.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a602d4bb0c8329b08aded76dbb2ec7