### PR TITLE
Handle pandas NA in expected points

### DIFF
--- a/tests/test_safe_stat_pd_na.py
+++ b/tests/test_safe_stat_pd_na.py
@@ -2,6 +2,7 @@ import pandas as pd
 
 from utils.poisson_utils.team_analysis import (
     expected_goals_combined_homeaway_allmatches,
+    calculate_expected_and_actual_points,
 )
 
 
@@ -24,3 +25,26 @@ def test_expected_goals_handles_pandas_na():
 
     assert isinstance(home, float)
     assert isinstance(away, float)
+
+
+def test_expected_points_handles_pandas_na():
+    df = pd.DataFrame(
+        {
+            "Date": ["2024-01-01"],
+            "HomeTeam": ["Existing"],
+            "AwayTeam": ["Other"],
+            "FTHG": [1],
+            "FTAG": [1],
+            "HS": [pd.NA],
+            "HST": [pd.NA],
+            "AS": [pd.NA],
+            "AST": [pd.NA],
+        }
+    )
+
+    res = calculate_expected_and_actual_points(df)
+
+    assert res["Existing"]["points"] == 1
+    assert res["Other"]["points"] == 1
+    assert isinstance(res["Existing"]["expected_points"], float)
+    assert isinstance(res["Other"]["expected_points"], float)

--- a/utils/poisson_utils/team_analysis.py
+++ b/utils/poisson_utils/team_analysis.py
@@ -106,14 +106,20 @@ def calculate_expected_and_actual_points(df: pd.DataFrame) -> dict:
 
         # Očekávané body (xP) přes Poisson z proxy xG
         xP = 0.0
+
+        def _sot_to_xg(sot, shots):
+            sot = 0 if pd.isna(sot) else sot
+            shots = 0 if pd.isna(shots) else shots
+            return (sot / shots) if shots > 0 else 0.1
+
         for row in all_matches.itertuples(index=False):
             if row.HomeTeam == team:
-                xg_for = (row.HST / row.HS) if row.HS > 0 else 0.1
-                xg_against = (row.AST / row.AS) if row.AS > 0 else 0.1
+                xg_for = _sot_to_xg(row.HST, row.HS)
+                xg_against = _sot_to_xg(row.AST, row.AS)
                 team_is_home = True
             elif row.AwayTeam == team:
-                xg_for = (row.AST / row.AS) if row.AS > 0 else 0.1
-                xg_against = (row.HST / row.HS) if row.HS > 0 else 0.1
+                xg_for = _sot_to_xg(row.AST, row.AS)
+                xg_against = _sot_to_xg(row.HST, row.HS)
                 team_is_home = False
             else:
                 continue


### PR DESCRIPTION
## Summary
- avoid NAType errors in `calculate_expected_and_actual_points`
- cover expected points calculation with missing shot data

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a60a9e2e608329b6e4eff3f16d5539