### PR TITLE
Add ELO tables for UEFA cups

### DIFF
--- a/sections/uefa_cup_section.py
+++ b/sections/uefa_cup_section.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from utils.poisson_utils.cup_predictions import predict_cup_match
 from utils.poisson_utils.data import prepare_df
+from utils.poisson_utils.elo import calculate_elo_ratings
 
 CUP_FILES = {
     "Champions League": "CL_combined_full.csv",
@@ -55,13 +56,52 @@ def load_upcoming_cup_fixtures(data_dir: str | Path = "data") -> pd.DataFrame:
     return pd.concat(frames, ignore_index=True).sort_values("Date")
 
 
+@st.cache_data
+def load_cup_elo_tables(data_dir: str | Path = "data") -> dict[str, pd.DataFrame]:
+    """Return ELO rating tables for available UEFA cups."""
+
+    data_dir = Path(data_dir)
+    tables: dict[str, pd.DataFrame] = {}
+    for competition, filename in CUP_FILES.items():
+        path = data_dir / filename
+        if not path.exists():
+            continue
+        try:
+            df = pd.read_csv(path)
+        except Exception:
+            continue
+        df = prepare_df(df)
+        if {"FTHG", "FTAG"}.issubset(df.columns):
+            df = df.dropna(subset=["FTHG", "FTAG"])
+        else:
+            continue
+        if df.empty:
+            continue
+        elo_dict = calculate_elo_ratings(df)
+        elo_table = (
+            pd.DataFrame({"Team": elo_dict.keys(), "ELO": elo_dict.values()})
+            .sort_values("ELO", ascending=False)
+            .reset_index(drop=True)
+        )
+        tables[competition] = elo_table
+
+    return tables
+
+
 def render_uefa_cup_predictions(cross_league_df: pd.DataFrame, data_dir: str | Path = "data") -> None:
     """Render table of predicted outcomes for upcoming UEFA cup fixtures."""
 
     st.header("🏆 UEFA Cup Predictions")
+    elo_tables = load_cup_elo_tables(data_dir)
+    for competition, table in elo_tables.items():
+        st.subheader(f"{competition} ELO Ratings")
+        st.dataframe(table, hide_index=True, use_container_width=True)
+
     fixtures = load_upcoming_cup_fixtures(data_dir)
     if fixtures.empty:
-        st.info("No upcoming fixtures found for the Champions League, Europa League or Conference League.")
+        st.info(
+            "No upcoming fixtures found for the Champions League, Europa League or Conference League."
+        )
         return
 
     rows: list[dict] = []


### PR DESCRIPTION
## Summary
- show per-competition ELO rating tables in UEFA cup Streamlit section
- load cup ELO ratings from freshly generated CSV files

## Testing
- `python scripts/update_uefa_cups.py` *(fails: KeyError: 'FOOTBALL_DATA_TOKEN')*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a60cc0735c83299bcfbba8528b5b52