### PR TITLE
Remove token from league data refresh workflow

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -11,8 +11,6 @@ permissions:
 jobs:
   update:
     runs-on: ubuntu-latest
-    env:
-      FOOTBALL_DATA_TOKEN: ${{ secrets.FOOTBALL_DATA_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -31,8 +29,6 @@ jobs:
           git config user.email github-actions@github.com
       - name: Update league data
         run: python update_league_data.py
-      - name: Update UEFA cups data
-        run: python scripts/update_uefa_cups.py
       - name: Commit and push changes
         run: python commit_and_push.py
         env:


### PR DESCRIPTION
## Summary
- simplify `refresh-data.yml` to refresh only league CSVs
- drop `FOOTBALL_DATA_TOKEN` env and UEFA cups step

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a72373b40c83299c5f92c3b7dc0c91