### PR TITLE
feat: expand random forest feature set

### DIFF
--- a/tests/test_random_forest_model.py
+++ b/tests/test_random_forest_model.py
@@ -30,6 +30,13 @@ def test_construct_features():
     assert feats["away_recent_form"] == pytest.approx(-2/3)
     assert feats["elo_diff"] == 100
     assert feats["xg_diff"] == pytest.approx(0.6)
+    assert feats["home_conceded"] == pytest.approx(0.8)
+    assert feats["away_conceded"] == pytest.approx(5 / 3)
+    assert feats["conceded_diff"] == pytest.approx(-13 / 15)  # -0.8666...
+    assert feats["home_advantage"] == 1.0
+    assert feats["days_since_last_match"] == 0
+    assert feats["attack_strength_diff"] == pytest.approx(0.5)
+    assert feats["defense_strength_diff"] == pytest.approx(-11 / 12)
 
 
 def test_predict_proba_deterministic():


### PR DESCRIPTION
## Summary
- include rolling conceded goals and their difference in expected goals computation
- add home advantage, rest days, and attack/defense strength indicators
- extend feature construction and tests for the new metrics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa2eb06f60832991e14e4d5769a6a7