### PR TITLE
Optimize RandomForest with RandomizedSearchCV and persist best params

### DIFF
--- a/sections/match_prediction_section.py
+++ b/sections/match_prediction_section.py
@@ -66,7 +66,7 @@ from utils.ml.random_forest import (
 def get_rf_model():
     return load_model()
 
-RF_MODEL, RF_FEATURE_NAMES, RF_LABEL_ENCODER = get_rf_model()
+RF_MODEL, RF_FEATURE_NAMES, RF_LABEL_ENCODER, _ = get_rf_model()
 
 @st.cache_data
 def load_upcoming_xg() -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- Tune RandomForest hyperparameters via RandomizedSearchCV and return best score and parameters
- Store best model parameters in the saved joblib file and expose them when loading
- Adjust model consumers to handle the enriched model data structure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa2fb19d8483298725d61b2fc5c45f