### PR TITLE
Handle optional metadata from RF model

### DIFF
--- a/sections/match_prediction_section.py
+++ b/sections/match_prediction_section.py
@@ -65,8 +65,12 @@ from utils.ml.random_forest import (
 @st.cache_resource
 def get_rf_model():
     return load_model()
-
-RF_MODEL, RF_FEATURE_NAMES, RF_LABEL_ENCODER, _ = get_rf_model()
+# ``load_model`` historically returned three or four values depending on
+# whether metadata (like ``best_params``) was available.  Using extended
+# unpacking here allows the Streamlit app to remain compatible with either
+# return signature without raising ``ValueError`` when fewer items are
+# provided.
+RF_MODEL, RF_FEATURE_NAMES, RF_LABEL_ENCODER, *_ = get_rf_model()
 
 @st.cache_data
 def load_upcoming_xg() -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- Prevent ValueError when loading the random forest model by using extended unpacking so the code works whether metadata is present or not.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa340631348329bbf76353add8d867