### PR TITLE
Add match prediction shortcuts to league overview

### DIFF
--- a/sections/match_prediction_section.py
+++ b/sections/match_prediction_section.py
@@ -82,7 +82,7 @@ def load_upcoming_xg() -> pd.DataFrame:
     path = "data/Footballxg.com - (F1X) xG Free Upcoming v3.1.xlsx"
     cols = [
         "Date", "Home Team", "Away Team", "xG Home", "xG Away",
-        "Home", "Draw", "Away", ">2.5",
+        "Home", "Draw", "Away", ">2.5", "League",
     ]
     try:
         return pd.read_excel(path, header=5, usecols=cols)


### PR DESCRIPTION
## Summary
- load league info when reading upcoming xG workbook
- show upcoming matches in league overview with quick links to detailed predictions
- support navigation and team preselection via URL query parameters

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aab98b6c8883298e5b6519716f9d27