### PR TITLE
Add match prediction shortcuts to league overview

### DIFF
--- a/sections/match_prediction_section.py
+++ b/sections/match_prediction_section.py
@@ -81,14 +81,45 @@ def load_upcoming_xg() -> pd.DataFrame:
     """
     path = "data/Footballxg.com - (F1X) xG Free Upcoming v3.1.xlsx"
     cols = [
-        "Date", "Home Team", "Away Team", "xG Home", "xG Away",
-        "Home", "Draw", "Away", ">2.5",
+        "Date",
+        "Home Team",
+        "Away Team",
+        "xG Home",
+        "xG Away",
+        "Home",
+        "Draw",
+        "Away",
+        ">2.5",
+        "League",
     ]
     try:
-        return pd.read_excel(path, header=5, usecols=cols)
+        df = pd.read_excel(path, header=5, usecols=cols)
     except Exception as exc:  # pragma: no cover - safeguards runtime
         st.warning(f"Could not load xG workbook: {exc}")
         return pd.DataFrame(columns=cols)
+
+    # Remove placeholder rows and map league names to internal codes so
+    # downstream consumers can filter by domestic competition.
+    df = df.dropna(subset=["Home Team", "Away Team"])
+    league_map = {
+        "England - Premier League": "E0",
+        "England - Championship": "E1",
+        "Spain - La Liga": "SP1",
+        "Belgium - Jupiler League": "B1",
+        "Germany - Bundesliga": "D1",
+        "Germany - 2.Bundesliga": "D2",
+        "Italy - Serie A": "I1",
+        "France - Ligue 1": "F1",
+        "Netherlands - Eredivisie": "N1",
+        "Portugal - Primeira Liga": "P1",
+        "Turkey - Super Lig": "T1",
+    }
+    df["LeagueCode"] = df["League"].map(league_map)
+    # Drop rows from competitions we don't recognise so downstream consumers
+    # (e.g. league overview) won't display fixtures that aren't actually in the
+    # xG workbook.
+    df = df.dropna(subset=["LeagueCode"])
+    return df
 
 
 def lookup_xg_row(

--- a/sections/overview_section.py
+++ b/sections/overview_section.py
@@ -18,6 +18,7 @@ from utils.poisson_utils import (
     get_team_xg_xga,
 )
 from utils.statistics import calculate_clean_sheets
+from sections.match_prediction_section import load_upcoming_xg
 
 
 @st.cache_data
@@ -216,3 +217,34 @@ def render_league_overview(season_df, league_name, gii_dict, elo_dict):
     cols2[3].dataframe(
         def_df.head(5)[["Tým", "Defenzivní styl index"]], hide_index=True
     )
+
+    # Upcoming matches from xG data with shortcuts to predictions.  Use the
+    # league code from the dataset itself rather than relying on the display
+    # name to avoid mismatches.
+    xg_df = load_upcoming_xg()
+    league_code = season_df["Div"].iloc[0]
+    upcoming = (
+        xg_df[xg_df["LeagueCode"] == league_code][["Date", "Home Team", "Away Team"]]
+        .sort_values("Date")
+    )
+    if not upcoming.empty:
+        st.markdown("### 📅 Upcoming matches")
+
+        def match_link(row: pd.Series) -> str:
+            encoded_league = urllib.parse.quote_plus(league_name)
+            home = urllib.parse.quote_plus(row["Home Team"])
+            away = urllib.parse.quote_plus(row["Away Team"])
+            return (
+                f"?selected_league={encoded_league}&home_team={home}&away_team={away}&view=match"
+            )
+
+        display_df = upcoming.copy()
+        display_df.insert(3, "Prediction", upcoming.apply(match_link, axis=1))
+        st.dataframe(
+            display_df,
+            column_config={
+                "Prediction": st.column_config.LinkColumn("Prediction", display_text="🔮"),
+            },
+            hide_index=True,
+            use_container_width=True,
+        )


### PR DESCRIPTION
## Summary
- drop unrecognised competitions when reading upcoming xG workbook so only valid fixtures are returned
- derive league code from season data to ensure overview lists matches only from the xG workbook

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aab98b6c8883298e5b6519716f9d27