### PR TITLE
Fix xG data cleanup and upcoming match loading

### DIFF
--- a/sections/match_prediction_section.py
+++ b/sections/match_prediction_section.py
@@ -93,8 +93,14 @@ def load_upcoming_xg() -> pd.DataFrame:
     # Normalizace a čištění
     df = df.dropna(subset=["Date", "Home Team", "Away Team"]).copy()
     df["Date"] = pd.to_datetime(df["Date"], errors="coerce").dt.normalize()
-    df["Home Team"] = df["Home Team"].astype(str).strip()
-    df["Away Team"] = df["Away Team"].astype(str).strip()
+    # ``astype(str)`` converts any non-string entries (e.g. numbers or NaN)
+    # into string form.  ``Series.str.strip`` must then be used to remove
+    # leading/trailing whitespace from each element.  The previous version
+    # mistakenly called ``strip`` directly on the Series object which raised
+    # ``AttributeError`` because ``strip`` is a string method, not a Series
+    # method.
+    df["Home Team"] = df["Home Team"].astype(str).str.strip()
+    df["Away Team"] = df["Away Team"].astype(str).str.strip()
 
     # Mapování lig na interní kódy (Div)
     league_map = {

--- a/sections/overview_section.py
+++ b/sections/overview_section.py
@@ -219,37 +219,37 @@ def render_league_overview(season_df, league_name, gii_dict, elo_dict):
         def_df.head(5)[["Tým", "Defenzivní styl index"]], hide_index=True
     )
 
-# 📅 Upcoming matches from xG data with shortcuts to predictions.
-# Použijeme kód soutěže ze season_df, aby nedocházelo k nesouladu názvů.
-xg_df = load_upcoming_xg()
-league_code = season_df["Div"].iloc[0]
+    # 📅 Upcoming matches from xG data with shortcuts to predictions.
+    # Použijeme kód soutěže ze season_df, aby nedocházelo k nesouladu názvů.
+    xg_df = load_upcoming_xg()
+    league_code = season_df["Div"].iloc[0]
 
-upcoming = (
-    xg_df.loc[xg_df["LeagueCode"] == league_code, ["Date", "Home Team", "Away Team"]]
+    upcoming = (
+        xg_df.loc[xg_df["LeagueCode"] == league_code, ["Date", "Home Team", "Away Team"]]
         .copy()
-)
-
-if not upcoming.empty:
-    # Normalizace/parsování data a seřazení
-    upcoming["Date"] = pd.to_datetime(upcoming["Date"], errors="coerce").dt.date
-    upcoming = upcoming.sort_values("Date").reset_index(drop=True)
-
-    st.markdown("### 📅 Upcoming matches")
-
-    def match_link(row: pd.Series) -> str:
-        encoded_league = urllib.parse.quote_plus(league_name)
-        home = urllib.parse.quote_plus(row["Home Team"])
-        away = urllib.parse.quote_plus(row["Away Team"])
-        return f"?selected_league={encoded_league}&home_team={home}&away_team={away}&view=match"
-
-    display_df = upcoming.copy()
-    display_df.insert(3, "Prediction", upcoming.apply(match_link, axis=1))
-
-    st.dataframe(
-        display_df,
-        column_config={
-            "Prediction": st.column_config.LinkColumn("Prediction", display_text="🔮"),
-        },
-        hide_index=True,
-        use_container_width=True,
     )
+
+    if not upcoming.empty:
+        # Normalizace/parsování data a seřazení
+        upcoming["Date"] = pd.to_datetime(upcoming["Date"], errors="coerce").dt.date
+        upcoming = upcoming.sort_values("Date").reset_index(drop=True)
+
+        st.markdown("### 📅 Upcoming matches")
+
+        def match_link(row: pd.Series) -> str:
+            encoded_league = urllib.parse.quote_plus(league_name)
+            home = urllib.parse.quote_plus(row["Home Team"])
+            away = urllib.parse.quote_plus(row["Away Team"])
+            return f"?selected_league={encoded_league}&home_team={home}&away_team={away}&view=match"
+
+        display_df = upcoming.copy()
+        display_df.insert(3, "Prediction", upcoming.apply(match_link, axis=1))
+
+        st.dataframe(
+            display_df,
+            column_config={
+                "Prediction": st.column_config.LinkColumn("Prediction", display_text="🔮"),
+            },
+            hide_index=True,
+            use_container_width=True,
+        )


### PR DESCRIPTION
## Summary
- ensure Series.str.strip is used when normalizing team names in xG data
- load and filter upcoming xG matches inside `render_league_overview` so `season_df` is available

## Testing
- `pytest tests/test_upcoming_xg.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aac3632c8083298cb6b38fadddffdb