### PR TITLE
Fix upcoming match links for normalized team names

### DIFF
--- a/sections/match_prediction_section.py
+++ b/sections/match_prediction_section.py
@@ -62,6 +62,20 @@ from utils.ml.random_forest import (
     predict_proba,
 )
 
+# Map team names from the external xG workbook to the naming used in our
+# datasets.  Without this normalisation query parameters constructed from the
+# workbook (e.g. "Man Utd") would not match the labels present in the league
+# data ("Man United") causing the match prediction page to default to the first
+# available team.  The mapping below covers all differences currently found in
+# the workbook.
+TEAM_NAME_MAP = {
+    "Man Utd": "Man United",
+    "Bayer Leverkusen": "Leverkusen",
+    "B Monchengladbach": "M'gladbach",
+    "Rayo Vallecano": "Vallecano",
+    "Real Sociedad": "Sociedad",
+}
+
 @st.cache_resource
 def get_rf_model():
     return load_model()
@@ -99,8 +113,12 @@ def load_upcoming_xg() -> pd.DataFrame:
     # mistakenly called ``strip`` directly on the Series object which raised
     # ``AttributeError`` because ``strip`` is a string method, not a Series
     # method.
-    df["Home Team"] = df["Home Team"].astype(str).str.strip()
-    df["Away Team"] = df["Away Team"].astype(str).str.strip()
+    df["Home Team"] = (
+        df["Home Team"].astype(str).str.strip().replace(TEAM_NAME_MAP)
+    )
+    df["Away Team"] = (
+        df["Away Team"].astype(str).str.strip().replace(TEAM_NAME_MAP)
+    )
 
     # Mapování lig na interní kódy (Div)
     league_map = {

--- a/sections/overview_section.py
+++ b/sections/overview_section.py
@@ -230,6 +230,15 @@ def render_league_overview(season_df, league_name, gii_dict, elo_dict):
     )
 
     if not upcoming.empty:
+        # Only keep matches where both teams exist in the current season data.
+        teams_in_season = set(season_df["HomeTeam"].unique()) | set(
+            season_df["AwayTeam"].unique()
+        )
+        upcoming = upcoming[
+            upcoming["Home Team"].isin(teams_in_season)
+            & upcoming["Away Team"].isin(teams_in_season)
+        ]
+
         # Normalizace/parsování data a seřazení
         upcoming["Date"] = pd.to_datetime(upcoming["Date"], errors="coerce").dt.date
         upcoming = upcoming.sort_values("Date").reset_index(drop=True)

--- a/tests/test_upcoming_xg.py
+++ b/tests/test_upcoming_xg.py
@@ -1,9 +1,10 @@
 import pandas as pd
 import pathlib
 import sys
+import glob
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
-from sections.match_prediction_section import load_upcoming_xg
+from sections.match_prediction_section import load_upcoming_xg, TEAM_NAME_MAP
 
 def test_upcoming_xg_data_integrity():
     df = load_upcoming_xg()
@@ -13,3 +14,24 @@ def test_upcoming_xg_data_integrity():
     d1 = df[df['LeagueCode'] == 'D1']
     assert ((d1['Home Team'] == 'Mainz') & (d1['Away Team'] == 'FC Koln')).any()
     assert not ((d1['Home Team'] == 'Mainz') & (d1['Away Team'] == 'Hoffenheim')).any()
+
+
+def test_team_name_normalization():
+    df = load_upcoming_xg()
+
+    # All shorthand team names from the workbook should be replaced by the
+    # canonical names from our datasets.
+    teams = pd.unique(df[['Home Team', 'Away Team']].values.ravel())
+    for shorthand, canonical in TEAM_NAME_MAP.items():
+        assert shorthand not in teams
+        assert canonical in teams
+
+    # Additionally ensure the remaining team names all exist in the dataset
+    # league files so future differences are detected.
+    dataset_teams = set()
+    for path in glob.glob('data/*_combined_full_updated.csv'):
+        csv = pd.read_csv(path, usecols=['HomeTeam', 'AwayTeam'])
+        dataset_teams.update(csv['HomeTeam'].unique())
+        dataset_teams.update(csv['AwayTeam'].unique())
+
+    assert set(teams).issubset(dataset_teams)


### PR DESCRIPTION
## Summary
- Normalize all differing team names from the xG workbook (e.g. `Bayer Leverkusen` → `Leverkusen`, `Rayo Vallecano` → `Vallecano`) so prediction links choose correct teams
- Add regression test verifying the full mapping and detecting any new mismatches

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aac67bf4bc8329b76e6cb1904fd99b