### PR TITLE
Fix upcoming match links for normalized team names

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,7 @@ from sections.team_detail_section import render_team_detail
 from sections.my_bets_section import render_my_bets_section as render_my_bets
 from sections.cross_league_section import render_cross_league_ratings
 from sections.uefa_cup_section import render_uefa_cup_predictions
+from utils.navigation import clear_query_params_on_nav_change
 
 import urllib.parse
 
@@ -357,14 +358,12 @@ navigation = st.sidebar.radio(
     index=default_nav_idx,
 )
 
-# Clear selected team and match params when switching navigation to avoid stale selection
-if "last_navigation" not in st.session_state:
-    st.session_state["last_navigation"] = navigation
-elif st.session_state["last_navigation"] != navigation:
-    st.session_state["last_navigation"] = navigation
-    for param in ("selected_team", "home_team", "away_team", "view"):
-        if param in query_params:
-            del query_params[param]
+# Clear selected team and match params when switching navigation to avoid stale selection.
+# When navigation comes from a match link (``view=match``) the parameters must
+# remain so the match prediction page can preselect the correct teams.
+clear_query_params_on_nav_change(
+    st.session_state, query_params, navigation, view_param
+)
 
 # --- Výběr týmů ---
 teams_in_season = sorted(

--- a/sections/match_prediction_section.py
+++ b/sections/match_prediction_section.py
@@ -62,6 +62,20 @@ from utils.ml.random_forest import (
     predict_proba,
 )
 
+# Map team names from the external xG workbook to the naming used in our
+# datasets.  Without this normalisation query parameters constructed from the
+# workbook (e.g. "Man Utd") would not match the labels present in the league
+# data ("Man United") causing the match prediction page to default to the first
+# available team.  The mapping below covers all differences currently found in
+# the workbook.
+TEAM_NAME_MAP = {
+    "Man Utd": "Man United",
+    "Bayer Leverkusen": "Leverkusen",
+    "B Monchengladbach": "M'gladbach",
+    "Rayo Vallecano": "Vallecano",
+    "Real Sociedad": "Sociedad",
+}
+
 @st.cache_resource
 def get_rf_model():
     return load_model()
@@ -99,8 +113,12 @@ def load_upcoming_xg() -> pd.DataFrame:
     # mistakenly called ``strip`` directly on the Series object which raised
     # ``AttributeError`` because ``strip`` is a string method, not a Series
     # method.
-    df["Home Team"] = df["Home Team"].astype(str).str.strip()
-    df["Away Team"] = df["Away Team"].astype(str).str.strip()
+    df["Home Team"] = (
+        df["Home Team"].astype(str).str.strip().replace(TEAM_NAME_MAP)
+    )
+    df["Away Team"] = (
+        df["Away Team"].astype(str).str.strip().replace(TEAM_NAME_MAP)
+    )
 
     # Mapování lig na interní kódy (Div)
     league_map = {

--- a/sections/overview_section.py
+++ b/sections/overview_section.py
@@ -230,6 +230,15 @@ def render_league_overview(season_df, league_name, gii_dict, elo_dict):
     )
 
     if not upcoming.empty:
+        # Only keep matches where both teams exist in the current season data.
+        teams_in_season = set(season_df["HomeTeam"].unique()) | set(
+            season_df["AwayTeam"].unique()
+        )
+        upcoming = upcoming[
+            upcoming["Home Team"].isin(teams_in_season)
+            & upcoming["Away Team"].isin(teams_in_season)
+        ]
+
         # Normalizace/parsování data a seřazení
         upcoming["Date"] = pd.to_datetime(upcoming["Date"], errors="coerce").dt.date
         upcoming = upcoming.sort_values("Date").reset_index(drop=True)

--- a/tests/test_navigation_query_params.py
+++ b/tests/test_navigation_query_params.py
@@ -1,0 +1,19 @@
+from utils.navigation import clear_query_params_on_nav_change
+
+
+def test_match_link_preserves_query_params():
+    session_state = {"last_navigation": "League overview"}
+    query_params = {"home_team": "Fulham", "away_team": "Man United", "view": "match"}
+    clear_query_params_on_nav_change(session_state, query_params, "Match prediction", "match")
+    assert query_params == {
+        "home_team": "Fulham",
+        "away_team": "Man United",
+        "view": "match",
+    }
+
+
+def test_manual_navigation_clears_query_params():
+    session_state = {"last_navigation": "Match prediction"}
+    query_params = {"home_team": "Fulham", "away_team": "Man United", "view": "match"}
+    clear_query_params_on_nav_change(session_state, query_params, "League overview", "match")
+    assert query_params == {}

--- a/tests/test_upcoming_xg.py
+++ b/tests/test_upcoming_xg.py
@@ -1,9 +1,10 @@
 import pandas as pd
 import pathlib
 import sys
+import glob
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
-from sections.match_prediction_section import load_upcoming_xg
+from sections.match_prediction_section import load_upcoming_xg, TEAM_NAME_MAP
 
 def test_upcoming_xg_data_integrity():
     df = load_upcoming_xg()
@@ -13,3 +14,24 @@ def test_upcoming_xg_data_integrity():
     d1 = df[df['LeagueCode'] == 'D1']
     assert ((d1['Home Team'] == 'Mainz') & (d1['Away Team'] == 'FC Koln')).any()
     assert not ((d1['Home Team'] == 'Mainz') & (d1['Away Team'] == 'Hoffenheim')).any()
+
+
+def test_team_name_normalization():
+    df = load_upcoming_xg()
+
+    # All shorthand team names from the workbook should be replaced by the
+    # canonical names from our datasets.
+    teams = pd.unique(df[['Home Team', 'Away Team']].values.ravel())
+    for shorthand, canonical in TEAM_NAME_MAP.items():
+        assert shorthand not in teams
+        assert canonical in teams
+
+    # Additionally ensure the remaining team names all exist in the dataset
+    # league files so future differences are detected.
+    dataset_teams = set()
+    for path in glob.glob('data/*_combined_full_updated.csv'):
+        csv = pd.read_csv(path, usecols=['HomeTeam', 'AwayTeam'])
+        dataset_teams.update(csv['HomeTeam'].unique())
+        dataset_teams.update(csv['AwayTeam'].unique())
+
+    assert set(teams).issubset(dataset_teams)

--- a/utils/navigation.py
+++ b/utils/navigation.py
@@ -1,0 +1,40 @@
+"""Utility functions for navigation and query parameter handling."""
+
+from typing import MutableMapping, Any
+
+
+def clear_query_params_on_nav_change(
+    session_state: MutableMapping[str, Any],
+    query_params: MutableMapping[str, Any],
+    navigation: str,
+    view_param: str | None,
+) -> None:
+    """Clear stale query parameters when user switches app navigation.
+
+    Parameters
+    ----------
+    session_state:
+        Streamlit-like session state object used to track last navigation.
+    query_params:
+        Mutable mapping of the current query parameters (e.g. ``st.query_params``).
+    navigation:
+        The navigation label currently selected by the user.
+    view_param:
+        Value of the ``view`` query parameter if present.
+
+    When navigation changes because the user clicked a link that already
+    specifies ``view=match`` along with ``home_team`` and ``away_team``, these
+    parameters must persist so the match prediction page can preselect the
+    correct teams.  In all other cases the parameters are cleared to avoid
+    stale selections.
+    """
+
+    link_triggered = view_param == "match" and navigation == "Match prediction"
+
+    if "last_navigation" not in session_state:
+        session_state["last_navigation"] = navigation
+    elif session_state["last_navigation"] != navigation:
+        session_state["last_navigation"] = navigation
+        if not link_triggered:
+            for param in ("selected_team", "home_team", "away_team", "view"):
+                query_params.pop(param, None)


### PR DESCRIPTION
## Summary
- Preserve `home_team` and `away_team` query params when navigating via match links so predictions select intended clubs
- Add navigation helper with tests to ensure match links retain teams and stale params are cleared when switching views

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aac67bf4bc8329b76e6cb1904fd99b