### PR TITLE
Refactor match prediction metrics

### DIFF
--- a/sections/match_prediction_section.py
+++ b/sections/match_prediction_section.py
@@ -313,8 +313,6 @@ def display_metrics(
     corner_away_exp: float,
     corner_probs: Dict[str, float],
     corner_line: float,
-    ml_probs: Optional[Dict[str, float]] = None,
-    over25_ml: Optional[float] = None,
     outcomes_xg: Optional[Dict[str, float]] = None,
     over25_xg: Optional[float] = None,
     secondary_outcomes: Optional[Dict[str, float]] = None,
@@ -350,31 +348,6 @@ def display_metrics(
                    f"{corner_probs[over_key]:.1f}%",
                    f"{1 / (corner_probs[over_key] / 100):.2f}")
     cols[2].caption(f"Under: {corner_probs[f'Under {corner_line}']:.1f}%")
-
-    # Volitelný blok pro ML 1X2 + ML Over 2.5
-    if ml_probs:
-        cols = responsive_columns(4 if over25_ml is not None else 3)
-        cols[0].metric(
-            "🏠 Výhra domácích (ML)",
-            f"{ml_probs['Home Win']:.1f}%",
-            f"{1 / (ml_probs['Home Win'] / 100):.2f}",
-        )
-        cols[1].metric(
-            "🤝 Remíza (ML)",
-            f"{ml_probs['Draw']:.1f}%",
-            f"{1 / (ml_probs['Draw'] / 100):.2f}",
-        )
-        cols[2].metric(
-            "🚶‍♂️ Výhra hostů (ML)",
-            f"{ml_probs['Away Win']:.1f}%",
-            f"{1 / (ml_probs['Away Win'] / 100):.2f}",
-        )
-        if over25_ml is not None:
-            cols[3].metric(
-                "⚽ Over 2.5 (ML)",
-                f"{over25_ml:.1f}%",
-                f"{1 / (over25_ml / 100):.2f}",
-            )
 
     st.markdown("## 🧠 Pravděpodobnosti výsledků")
     cols2 = responsive_columns(5 if over25 is not None else 4)
@@ -416,11 +389,27 @@ def display_metrics(
     if secondary_outcomes:
         st.markdown(f"### {secondary_label} model")
         cols_rf = responsive_columns(4 if secondary_over25 is not None else 3)
-        cols_rf[0].metric("🏠 Výhra domácích", f"{secondary_outcomes['Home Win']:.1f}%")
-        cols_rf[1].metric("🤝 Remíza", f"{secondary_outcomes['Draw']:.1f}%")
-        cols_rf[2].metric("🚶‍♂️ Výhra hostů", f"{secondary_outcomes['Away Win']:.1f}%")
+        cols_rf[0].metric(
+            f"🏠 Výhra domácích ({secondary_label})",
+            f"{secondary_outcomes['Home Win']:.1f}%",
+            f"{1 / (secondary_outcomes['Home Win'] / 100):.2f}",
+        )
+        cols_rf[1].metric(
+            f"🤝 Remíza ({secondary_label})",
+            f"{secondary_outcomes['Draw']:.1f}%",
+            f"{1 / (secondary_outcomes['Draw'] / 100):.2f}",
+        )
+        cols_rf[2].metric(
+            f"🚶‍♂️ Výhra hostů ({secondary_label})",
+            f"{secondary_outcomes['Away Win']:.1f}%",
+            f"{1 / (secondary_outcomes['Away Win'] / 100):.2f}",
+        )
         if secondary_over25 is not None:
-            cols_rf[3].metric("⚽ Over 2.5", f"{secondary_over25:.1f}%")
+            cols_rf[3].metric(
+                f"⚽ Over 2.5 ({secondary_label})",
+                f"{secondary_over25:.1f}%",
+                f"{1 / (secondary_over25 / 100):.2f}",
+            )
 
 
 
@@ -572,8 +561,6 @@ def render_single_match_prediction(
         corner_away_exp,
         corner_probs,
         corner_line,
-        ml_probs,
-        ml_over25,
         outcomes_xg,
         over25_xg,
         secondary_outcomes,


### PR DESCRIPTION
## Summary
- remove machine learning odds from the "Klíčové metriky" block
- show ML result probabilities with odds like Poisson and xG sections

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aadc5c1e9c8329a972294524d88632