### PR TITLE
Remove Confidence metric from UI

### DIFF
--- a/sections/match_prediction_section.py
+++ b/sections/match_prediction_section.py
@@ -53,7 +53,6 @@ from utils.anomaly_detection import (
     calculate_contrarian_risk_score,
     calculate_upset_risk_score,
     colored_risk_tag,
-    calculate_confidence_index
 )
 from utils import bet_db
 from utils.ml.random_forest import (
@@ -308,7 +307,6 @@ def display_metrics(
     over_under: Dict[str, float],
     outcomes: Dict[str, float],
     over25: Optional[float],
-    confidence_index: float,
     corner_home_exp: float,
     corner_away_exp: float,
     corner_probs: Dict[str, float],
@@ -350,7 +348,7 @@ def display_metrics(
     cols[2].caption(f"Under: {corner_probs[f'Under {corner_line}']:.1f}%")
 
     st.markdown("## 🧠 Pravděpodobnosti výsledků")
-    cols2 = responsive_columns(5 if over25 is not None else 4)
+    cols2 = responsive_columns(4 if over25 is not None else 3)
     cols2[0].metric("🏠 Výhra domácích",
                     f"{outcomes['Home Win']:.1f}%",
                     f"{1 / (outcomes['Home Win'] / 100):.2f}")
@@ -366,9 +364,6 @@ def display_metrics(
             f"{over25:.1f}%",
             f"{1 / (over25 / 100):.2f}",
         )
-        cols2[4].metric("🔒 Confidence", f"{confidence_index:.1f} %")
-    else:
-        cols2[3].metric("🔒 Confidence", f"{confidence_index:.1f} %")
 
     if outcomes_xg:
         cols3 = responsive_columns(4 if over25_xg is not None else 3)
@@ -513,17 +508,6 @@ def render_single_match_prediction(
     variance_flag = scoreline_variance_warning(matrix) is not None
     form_stability_score = 1.0  # Pokud nemáš metodu, klidně ponech 1.0
 
-    confidence_index = calculate_confidence_index(
-        outcomes=outcomes,
-        poisson_matrix=matrix,
-        warning_home=warning_index_home,
-        warning_away=warning_index_away,
-        form_stability_score=form_stability_score,
-        pos_home=pos_score_home,
-        pos_away=pos_score_away,
-        variance_warning=variance_flag,
-    )
-
     corner_line = st.sidebar.slider("Rohová hranice", 5.5, 15.5, 9.5, 0.5)
     corner_matrix = poisson_corner_matrix(corner_home_exp, corner_away_exp)
     corner_probs = corner_over_under_prob(corner_matrix, corner_line)
@@ -556,7 +540,6 @@ def render_single_match_prediction(
         over_under,
         primary_outcomes,
         primary_over25,
-        confidence_index,
         corner_home_exp,
         corner_away_exp,
         corner_probs,

--- a/sections/multi_prediction_section.py
+++ b/sections/multi_prediction_section.py
@@ -70,16 +70,11 @@ def render_multi_match_predictions(session_state, home_team, away_team, league_n
                         f"{over_under['Over 1.5']:.1f}% / {over_under['Over 2.5']:.1f}% / {over_under['Over 3.5']:.1f}%"
                     )
 
-                    # Confidence index = rozdíl dvou nejvyšších outcome pravděpodobností
-                    sorted_probs = sorted(outcomes.values(), reverse=True)
-                    confidence_index = round(sorted_probs[0] - sorted_probs[1], 1) if len(sorted_probs) >= 2 else 0.0
-
                     st.markdown("#### 🧠 Pravděpodobnosti výsledků")
-                    result_cols = responsive_columns(4)
+                    result_cols = responsive_columns(3)
                     result_cols[0].metric("🏠 Výhra domácích", f"{outcomes['Home Win']:.1f}%", f"{prob_to_odds(outcomes['Home Win'])}")
                     result_cols[1].metric("🤝 Remíza", f"{outcomes['Draw']:.1f}%", f"{prob_to_odds(outcomes['Draw'])}")
                     result_cols[2].metric("🚶‍♂️ Výhra hostů", f"{outcomes['Away Win']:.1f}%", f"{prob_to_odds(outcomes['Away Win'])}")
-                    result_cols[3].metric("🔒 Confidence", f"{confidence_index:.1f} %")
 
                     top_scores = get_top_scorelines(matrix, top_n=1)
                     top_score_str = f"{top_scores[0][0][0]}:{top_scores[0][0][1]}" if top_scores else "—"
@@ -104,7 +99,6 @@ def render_multi_match_predictions(session_state, home_team, away_team, league_n
                         "Draw %": round(outcomes["Draw"], 1),
                         "Away Win %": round(outcomes["Away Win"], 1),
                         "Top Score": top_score_str,
-                        "Confidence %": confidence_index,
                     })
 
                 except Exception as e:


### PR DESCRIPTION
## Summary
- drop Confidence metric from multi-match prediction results and exports
- simplify single-match display metrics to omit Confidence

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aade32bb9c8329be14ba176ca5d0b4