### PR TITLE
Add Match Dominance Index utility

### DIFF
--- a/utils/poisson_utils/__init__.py
+++ b/utils/poisson_utils/__init__.py
@@ -98,3 +98,4 @@ from .corners import (
 from .xg_sources import get_team_xg_xga
 from .cross_league import calculate_cross_league_team_index
 from .cup_predictions import predict_cup_match
+from .mdi import calculate_mdi

--- a/utils/poisson_utils/mdi.py
+++ b/utils/poisson_utils/mdi.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import pandas as pd
+
+
+WEIGHTS = {
+    "shots": 0.30,
+    "shots_on_target": 0.25,
+    "corners": 0.15,
+    "fouls": 0.10,
+    "yellow_cards": 0.10,
+    "red_cards": 0.10,
+}
+
+
+def calculate_mdi(
+    row: pd.Series, league_avgs: Dict[str, float], opponent_strength: float
+) -> float:
+    """Vypočítá index dominance zápasu (MDI).
+
+    Parametry
+    ---------
+    row : pd.Series
+        Řádek se statistikami zápasu (HS/AS, HST/AST, HC/AC, HF/AF, HY/AY, HR/AR).
+    league_avgs : dict
+        Průměrné hodnoty ligy pro uvedené statistiky.
+    opponent_strength : float
+        Koeficient síly soupeře (slabý < 1, silný > 1).
+
+    Returns
+    -------
+    float
+        Hodnota MDI v rozmezí 0–100.
+    """
+
+    score = 0.0
+
+    # Statistiky, kde vyšší hodnota je pozitivní
+    for home_col, away_col, weight_key in [
+        ("HS", "AS", "shots"),
+        ("HST", "AST", "shots_on_target"),
+        ("HC", "AC", "corners"),
+    ]:
+        home_norm = row.get(home_col, 0) / league_avgs.get(home_col, 1)
+        away_norm = row.get(away_col, 0) / league_avgs.get(away_col, 1)
+        score += (home_norm - away_norm) * WEIGHTS[weight_key]
+
+    # Statistiky, kde nižší hodnota je pozitivní
+    for home_col, away_col, weight_key in [
+        ("HF", "AF", "fouls"),
+        ("HY", "AY", "yellow_cards"),
+        ("HR", "AR", "red_cards"),
+    ]:
+        home_norm = row.get(home_col, 0) / league_avgs.get(home_col, 1)
+        away_norm = row.get(away_col, 0) / league_avgs.get(away_col, 1)
+        score += (away_norm - home_norm) * WEIGHTS[weight_key]
+
+    score *= 100 * opponent_strength
+    return float(max(0.0, min(100.0, score)))


### PR DESCRIPTION
## Summary
- add `calculate_mdi` to compute Match Dominance Index from match stats
- export `calculate_mdi` via poisson utils package

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac8fc728a8832995d33bdf2a33936b