### PR TITLE
Ensure MDI graph shows during team comparison

### DIFF
--- a/sections/team_detail_section.py
+++ b/sections/team_detail_section.py
@@ -203,13 +203,6 @@ def render_team_detail(
 
         footer_cols[0].plotly_chart(fig, use_container_width=True)
 
-        return
-
-
-
-
-
-
     st.header(f"📌 Detail týmu: {team}")
 
     # Výpočet pro všechny tři varianty
@@ -461,7 +454,7 @@ def render_team_detail(
     # )
     st.table(styled_matches)
 
-    # 📊 Match Dominance Index (MDI)
+    st.markdown("### 📊 Match Dominance Index (MDI)")
     league_avgs = season_df[["HS", "AS", "HST", "AST", "HC", "AC", "HF", "AF", "HY", "AY", "HR", "AR"]].mean().to_dict()
     strength_map = {"Silní": 1.1, "Průměrní": 1.0, "Slabí": 0.9}
 


### PR DESCRIPTION
## Summary
- prevent early return in team detail rendering so the MDI chart appears even when comparing teams
- add a heading for the Match Dominance Index section for clarity

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac94b62c048329a29e06c52d699900