### PR TITLE
Handle missing GII values in Over 2.5 checklist

### DIFF
--- a/checklist_rules.py
+++ b/checklist_rules.py
@@ -150,7 +150,8 @@ def over25_checklist(data: Dict[str, float], threshold: int = 7) -> ChecklistRes
         ),
         (
             "Both teams GII >0.3",
-            lambda d: d.get("gii_home", 0) > 0.3 and d.get("gii_away", 0) > 0.3,
+            lambda d: float(d.get("gii_home") or 0) > 0.3
+            and float(d.get("gii_away") or 0) > 0.3,
         ),
         (
             "Score variance >2.0",


### PR DESCRIPTION
## Summary
- Prevent TypeError in `over25_checklist` when GII values are missing by casting to float with a default of 0

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adaf33b4c08329828a97c1161e11df