### PR TITLE
Handle invalid GII values in Over 2.5 checklist

### DIFF
--- a/checklist_rules.py
+++ b/checklist_rules.py
@@ -73,6 +73,15 @@ def _evaluate_checklist(
 # ---------------------------------------------------------------------------
 
 
+def _to_float(value: float | str | None) -> float:
+    """Return ``value`` cast to ``float`` or ``0.0`` when conversion fails."""
+
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
 def _select_stat(
     data: Dict[str, float], specific_key: str, season_key: str, matches_key: str
 ) -> float:
@@ -84,8 +93,8 @@ def _select_stat(
     """
 
     if data.get(matches_key, 0) >= 5:
-        return float(data.get(specific_key, 0.0))
-    return float(data.get(season_key, 0.0))
+        return _to_float(data.get(specific_key))
+    return _to_float(data.get(season_key))
 
 
 # ---------------------------------------------------------------------------
@@ -150,7 +159,8 @@ def over25_checklist(data: Dict[str, float], threshold: int = 7) -> ChecklistRes
         ),
         (
             "Both teams GII >0.3",
-            lambda d: d.get("gii_home", 0) > 0.3 and d.get("gii_away", 0) > 0.3,
+            lambda d: _to_float(d.get("gii_home")) > 0.3
+            and _to_float(d.get("gii_away")) > 0.3,
         ),
         (
             "Score variance >2.0",

--- a/tests/test_checklist_rules.py
+++ b/tests/test_checklist_rules.py
@@ -1,0 +1,13 @@
+from checklist_rules import over25_checklist
+
+
+def test_over25_checklist_handles_invalid_gii() -> None:
+    data = {"gii_home": "N/A", "gii_away": 0.4}
+    result = over25_checklist(data)
+    assert result.rule_results["Both teams GII >0.3"] is False
+
+
+def test_over25_checklist_gii_rule_passes() -> None:
+    data = {"gii_home": "0.4", "gii_away": 0.5}
+    result = over25_checklist(data)
+    assert result.rule_results["Both teams GII >0.3"] is True


### PR DESCRIPTION
## Summary
- Safely cast checklist statistics to floats via `_to_float` helper so non-numeric GII values default to `0`
- Apply helper to GII rule in `over25_checklist` and to `_select_stat`
- Add regression tests for invalid and valid GII inputs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adaf33b4c08329828a97c1161e11df