### PR TITLE
Handle non-numeric checklist stats

### DIFF
--- a/checklist_rules.py
+++ b/checklist_rules.py
@@ -113,22 +113,32 @@ def over25_checklist(data: Dict[str, float], threshold: int = 7) -> ChecklistRes
         ),
         (
             "Both teams BTTS% >55%",
-            lambda d: d.get("btts_pct_home", 0) > 0.55 and d.get("btts_pct_away", 0) > 0.55,
+            lambda d: _to_float(d.get("btts_pct_home")) > 0.55
+            and _to_float(d.get("btts_pct_away")) > 0.55,
         ),
         (
             "Both teams Over2.5% >55%",
-            lambda d: d.get("over25_pct_home", 0) > 0.55 and d.get("over25_pct_away", 0) > 0.55,
+            lambda d: _to_float(d.get("over25_pct_home")) > 0.55
+            and _to_float(d.get("over25_pct_away")) > 0.55,
         ),
         (
             "Expected goals sum >2.8",
-            lambda d: d.get("poisson_home_exp", 0) + d.get("poisson_away_exp", 0) > 2.8,
+            lambda d: _to_float(d.get("poisson_home_exp"))
+            + _to_float(d.get("poisson_away_exp"))
+            > 2.8,
         ),
-        ("Expected tempo >40", lambda d: d.get("expected_tempo", 0) > 40),
+        (
+            "Expected tempo >40",
+            lambda d: _to_float(d.get("expected_tempo")) > 40,
+        ),
         (
             "Both teams GII >0.3",
             lambda d: _to_float(d.get("gii_home")) > 0.3 and _to_float(d.get("gii_away")) > 0.3,
         ),
-        ("Score variance >2.0", lambda d: d.get("score_var", 0) > 2.0),
+        (
+            "Score variance >2.0",
+            lambda d: _to_float(d.get("score_var")) > 2.0,
+        ),
     ]
     return _evaluate_checklist(data, rules, threshold)
 

--- a/tests/test_checklist_rules.py
+++ b/tests/test_checklist_rules.py
@@ -11,3 +11,15 @@ def test_over25_checklist_gii_rule_passes() -> None:
     data = {"gii_home": "0.4", "gii_away": 0.5}
     result = over25_checklist(data)
     assert result.rule_results["Both teams GII >0.3"] is True
+
+
+def test_over25_checklist_handles_percentage_strings() -> None:
+    data = {
+        "btts_pct_home": "0.6",
+        "btts_pct_away": 0.7,
+        "over25_pct_home": "0.7",
+        "over25_pct_away": "0.8",
+    }
+    result = over25_checklist(data)
+    assert result.rule_results["Both teams BTTS% >55%"] is True
+    assert result.rule_results["Both teams Over2.5% >55%"] is True


### PR DESCRIPTION
## Summary
- Cast numeric checklist stats to float to avoid type errors
- Add regression tests for string percentage values in Over 2.5 checklist

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adb3acf4388329a60dc49341d1f62e