### PR TITLE
Stop rendering team detail when comparing

### DIFF
--- a/sections/team_detail_section.py
+++ b/sections/team_detail_section.py
@@ -192,6 +192,10 @@ def render_team_detail(
 
         footer_cols[0].plotly_chart(fig, use_container_width=True)
 
+        # If a comparison team is selected, stop rendering the rest of the
+        # team detail view so that only the comparison section is displayed.
+        return
+
     st.header(f"📌 Detail týmu: {team}")
 
     # Výpočty


### PR DESCRIPTION
## Summary
- ensure team detail view does not render after selecting comparison team

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68add2d481ec8329ac11d79dd9799360