### PR TITLE
Use pyarrow for Parquet I/O

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ source venv/bin/activate  # Windows: venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
+Projekt využívá knihovnu `pyarrow` pro rychlejší čtení a zápis Parquet souborů, proto je zahrnuta v `requirements.txt`.
+
 Chceš-li stahovat data přes API-Football, vytvoř soubor `.env` s proměnnou `API_FOOTBALL_KEY`.
 
 ## 🚀 Spuštění aplikace

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ seaborn
 plotly
 XlsxWriter>=3.0.0
 openpyxl
+pyarrow
 
 requests
 beautifulsoup4

--- a/utils/poisson_utils/data.py
+++ b/utils/poisson_utils/data.py
@@ -61,7 +61,7 @@ def load_data(
             parse_dates=["Date"],
             usecols=columns,
         )
-        df_csv.to_parquet(parquet_path, index=False)
+        df_csv.to_parquet(parquet_path, index=False, engine="pyarrow")
         return df_csv
 
     if parquet_path.exists() and not force_refresh:
@@ -76,13 +76,13 @@ def load_data(
             ):
                 df = _read_csv()
             else:
-                df = pd.read_parquet(parquet_path, columns=columns)
+                df = pd.read_parquet(parquet_path, columns=columns, engine="pyarrow")
         else:
-            df = pd.read_parquet(parquet_path, columns=columns)
+            df = pd.read_parquet(parquet_path, columns=columns, engine="pyarrow")
     elif force_refresh and file_path.exists():
         df = _read_csv()
     elif parquet_path.exists():
-        df = pd.read_parquet(parquet_path, columns=columns)
+        df = pd.read_parquet(parquet_path, columns=columns, engine="pyarrow")
     else:
         df = _read_csv()
 


### PR DESCRIPTION
## Summary
- Add `pyarrow` dependency for fast Parquet operations
- Use the `pyarrow` engine when reading and writing cached Parquet files
- Document the new dependency in the installation instructions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68add917b4f08329a6068060ee60d2e0