### PR TITLE
Use shared requests session for league updates

### DIFF
--- a/tests/test_update_all_leagues.py
+++ b/tests/test_update_all_leagues.py
@@ -25,7 +25,17 @@ def test_update_all_leagues_adds_new_matches(tmp_path, monkeypatch):
             self.status_code = 200
             self.text = text
 
-    monkeypatch.setattr(update_data.requests, "get", lambda url: DummyResp(new_csv))
+    class DummySession:
+        def get(self, url, timeout=None, stream=False):
+            return DummyResp(new_csv)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(update_data.requests, "Session", lambda: DummySession())
     monkeypatch.chdir(tmp_path)
 
     messages = update_data.update_all_leagues()

--- a/utils/update_data.py
+++ b/utils/update_data.py
@@ -31,10 +31,10 @@ def normalize_keys(df):
 def update_all_leagues():
     messages = []
 
-    def fetch_league(code, url):
+    def fetch_league(session, code, url):
         try:
             print(f"🔄 Stahuji {code}...")
-            response = requests.get(url)
+            response = session.get(url, timeout=30, stream=True)
             if response.status_code != 200:
                 return code, None, f"❌ {code}: Stažení selhalo."
             df_new = pd.read_csv(StringIO(response.text))
@@ -44,9 +44,10 @@ def update_all_leagues():
             return code, None, f"❌ {code}: Chyba – {str(e)}"
 
     # Download all leagues concurrently
-    with ThreadPoolExecutor(max_workers=len(LEAGUES)) as executor:
-        futures = [executor.submit(fetch_league, code, url) for code, url in LEAGUES.items()]
-        results = [future.result() for future in futures]
+    with requests.Session() as session:
+        with ThreadPoolExecutor(max_workers=len(LEAGUES)) as executor:
+            futures = [executor.submit(fetch_league, session, code, url) for code, url in LEAGUES.items()]
+            results = [future.result() for future in futures]
 
     # Process and save after all downloads complete
     for code, df_new, error in results:


### PR DESCRIPTION
## Summary
- Reuse a shared `requests.Session` across worker threads when fetching league CSVs
- Update tests to accommodate session-based fetching

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68add9b2f870832996a0514d57ae251f