### PR TITLE
Include previous-season matches when current sample is small

### DIFF
--- a/tests/test_season_fallback.py
+++ b/tests/test_season_fallback.py
@@ -1,0 +1,32 @@
+import pandas as pd
+
+from utils.poisson_utils.data import (
+    prepare_df,
+    detect_current_season,
+    ensure_min_season_matches,
+)
+
+
+def test_ensure_min_season_matches_adds_previous_season():
+    dates_prev = pd.date_range('2023-02-01', periods=20, freq='7D')
+    prev = pd.DataFrame({
+        'Date': dates_prev,
+        'HomeTeam': ['A'] * 20,
+        'AwayTeam': ['B'] * 20,
+        'FTHG': 1,
+        'FTAG': 1,
+    })
+    dates_curr = pd.date_range('2023-08-01', periods=3, freq='7D')
+    curr = pd.DataFrame({
+        'Date': dates_curr,
+        'HomeTeam': ['A', 'A', 'A'],
+        'AwayTeam': ['B', 'C', 'D'],
+        'FTHG': 1,
+        'FTAG': 0,
+    })
+    df = pd.concat([prev, curr], ignore_index=True)
+    df = prepare_df(df)
+    season_df, season_start = detect_current_season(df, prepared=True)
+    augmented = ensure_min_season_matches(df, season_df, season_start, ['A'])
+    team_matches = augmented[(augmented['HomeTeam'] == 'A') | (augmented['AwayTeam'] == 'A')]
+    assert len(team_matches) == len(curr) + 10

--- a/utils/poisson_utils/__init__.py
+++ b/utils/poisson_utils/__init__.py
@@ -7,6 +7,7 @@ from .data import (
     get_last_n_matches,
     load_cup_matches,
     load_cup_team_stats,
+    ensure_min_season_matches,
 )
 
 from .stats import (

--- a/utils/poisson_utils/core.py
+++ b/utils/poisson_utils/core.py
@@ -3,6 +3,7 @@ from .data import (
     load_data,
     detect_current_season,
     get_last_n_matches,
+    ensure_min_season_matches,
 )
 
 from .stats import (
@@ -29,6 +30,7 @@ __all__ = [
     "load_data",
     "detect_current_season",
     "get_last_n_matches",
+    "ensure_min_season_matches",
     "aggregate_team_stats",
     "calculate_points",
     "add_btts_column",

--- a/utils/poisson_utils/data.py
+++ b/utils/poisson_utils/data.py
@@ -185,6 +185,36 @@ def get_last_n_matches(df, team, role="both", n=10):
     return matches.sort_values("Date").tail(n)
 
 
+def ensure_min_season_matches(
+    df: pd.DataFrame,
+    season_df: pd.DataFrame,
+    season_start: pd.Timestamp,
+    teams: list[str],
+    min_required: int = 10,
+    fallback_n: int = 10,
+) -> pd.DataFrame:
+    """Doplní zápasy z minulé sezony, pokud je aktuální vzorek malý.
+
+    Pokud má některý tým v ``season_df`` méně než ``min_required`` zápasů,
+    přidá se mu posledních ``fallback_n`` utkání před ``season_start``.
+    """
+
+    result = season_df.copy()
+    for team in teams:
+        mask = (result["HomeTeam"] == team) | (result["AwayTeam"] == team)
+        if mask.sum() < min_required:
+            prev = df[
+                (df["Date"] < season_start)
+                & ((df["HomeTeam"] == team) | (df["AwayTeam"] == team))
+            ].sort_values("Date").tail(fallback_n)
+            result = pd.concat([result, prev], ignore_index=True)
+
+    return (
+        result.drop_duplicates(subset=["Date", "HomeTeam", "AwayTeam"])
+        .sort_values("Date")
+    )
+
+
 def load_cup_matches(team_league_map: dict[str, str], data_dir: str | Path = "data") -> pd.DataFrame:
     """Load cup fixtures and map teams to their domestic leagues.
 

--- a/utils/poisson_utils/xg.py
+++ b/utils/poisson_utils/xg.py
@@ -2,7 +2,7 @@ import pandas as pd
 import numpy as np
 from typing import Dict, Tuple, Optional
 
-from .data import prepare_df
+from .data import prepare_df, detect_current_season, ensure_min_season_matches
 from .prediction import poisson_prediction
 
 
@@ -126,10 +126,11 @@ def expected_goals_weighted_by_elo(df: pd.DataFrame, home_team: str, away_team: 
     if cache_key in league_cache:
         return league_cache[cache_key]
 
-    latest_date = df['Date'].max()
-    one_year_ago = latest_date - pd.Timedelta(days=365)
-    df_hist = df[df['Date'] < one_year_ago]
-    df_season = df[df['Date'] >= one_year_ago]
+    season_df, season_start = detect_current_season(df, prepared=True)
+    df_hist = df[df['Date'] < season_start]
+    df_season = ensure_min_season_matches(
+        df, season_df, season_start, [home_team, away_team]
+    )
     df_last10 = df[
         (df['HomeTeam'] == home_team) | (df['AwayTeam'] == home_team) |
         (df['HomeTeam'] == away_team) | (df['AwayTeam'] == away_team)


### PR DESCRIPTION
## Summary
- add `ensure_min_season_matches` helper to augment season data with prior matches
- use the helper in Poisson expected-goal calculations to fall back to last season when fewer than 10 games played
- test that previous-season matches are appended when current season sample is small

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adf7c5ddf48329a16d6eed675b86e7