### PR TITLE
Add GII index to league overview table

### DIFF
--- a/sections/overview_section.py
+++ b/sections/overview_section.py
@@ -97,6 +97,9 @@ def compute_league_summary(season_df, gii_dict, elo_dict):
             ),
             "Over 2.5 %": team_stats.index.map(over25).astype(str) + "%",
             "BTTS %": team_stats.index.map(btts).astype(str) + "%",
+            "GII index": pd.Series(
+                [gii_dict.get(t) for t in team_stats.index], dtype="float"
+            ).round(2).values,
             "Intenzita": team_stats.index.map(
                 lambda t: intensity_score_to_emoji(gii_dict.get(t))
             ),


### PR DESCRIPTION
## Summary
- Display numeric GII index alongside intensity emoji in the league overview table
- Fix rounding error by casting GII values to float before rounding

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2a48ac3788329bbc778eebbc6ecb4