### PR TITLE
feat: show home advantage in overview

### DIFF
--- a/utils/poisson_utils/__init__.py
+++ b/utils/poisson_utils/__init__.py
@@ -59,6 +59,7 @@ from .team_analysis import (
     calculate_recent_team_form,
     calculate_expected_and_actual_points,
     calculate_strength_of_schedule,
+    calculate_team_home_advantage,
     analyze_opponent_strength,
     get_head_to_head_stats,
     merged_home_away_opponent_form,


### PR DESCRIPTION
## Summary
- display each team's home advantage in league overview tables
- expose `calculate_team_home_advantage` via utility package

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2ad4621d48329bb3e161c89e703c2