### PR TITLE
feat: pin team column in overview table

### DIFF
--- a/sections/overview_section.py
+++ b/sections/overview_section.py
@@ -172,6 +172,7 @@ def render_league_overview(season_df, league_name, gii_dict, elo_dict):
     st.dataframe(
         summary_table_display,
         column_config={
+            "Tým": st.column_config.TextColumn("Tým", pinned="left"),
             "Detail": st.column_config.LinkColumn("Detail", display_text="🔍"),
         },
         hide_index=True,


### PR DESCRIPTION
## Summary
- Pin "Tým" column to left in league overview table for better mobile navigation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2ae48eec88329bdf91fa616eea684