### PR TITLE
Fix over 2.5 goals probability calculation

### DIFF
--- a/utils/poisson_utils/prediction.py
+++ b/utils/poisson_utils/prediction.py
@@ -56,7 +56,9 @@ def poisson_over25_probability(home_exp: float, away_exp: float, max_goals: int 
     """
     goals = np.arange(0, max_goals + 1)
     matrix = np.outer(poisson.pmf(goals, home_exp), poisson.pmf(goals, away_exp))
-    prob_over = matrix[np.triu_indices_from(matrix, k=3)].sum()
+    prob_over = matrix[
+        np.add.outer(range(max_goals + 1), range(max_goals + 1)) >= 3
+    ].sum()
     return round(prob_over * 100, 2)
 
 


### PR DESCRIPTION
## Summary
- ensure `poisson_over25_probability` sums all goal combinations where the total is at least three

## Testing
- `pytest`
- `python - <<'PY'
from utils.poisson_utils.prediction import poisson_over25_probability
print(poisson_over25_probability(1.4, 1.1))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b3186e9be08329a8b320318db4eb79