### PR TITLE
Handle label encoder for over/under probabilities

### DIFF
--- a/utils/ml/random_forest.py
+++ b/utils/ml/random_forest.py
@@ -563,9 +563,15 @@ def predict_over25_proba(
     """Return the probability (0-100) that total goals exceed 2.5."""
     if model_data is None:
         model_data = load_over25_model(model_path)
-    model, feature_names, _ = model_data
+    model, feature_names, label_enc = model_data
     X = _clip_features(pd.DataFrame([features], columns=feature_names))
-    prob = model.predict_proba(X)[0][1]
+    probs = model.predict_proba(X)[0]
+    if label_enc is not None:
+        classes = label_enc.inverse_transform(np.arange(len(probs)))
+        over_idx = list(classes).index("Over 2.5")
+        prob = probs[over_idx]
+    else:
+        prob = probs[1]
     alpha = 0.15
     prob = (1 - alpha) * prob + alpha * 0.5
     return float(prob * 100)


### PR DESCRIPTION
## Summary
- Ensure `predict_over25_proba` respects the model's label encoder when selecting the Over 2.5 class
- Keep existing probability smoothing and percentage conversion

## Testing
- `pytest -q`
- Manual check of `predict_over25_proba` with dummy model and label encoder

------
https://chatgpt.com/codex/tasks/task_e_68b31a5a96e48329aae2bc6c6bed61a5