### PR TITLE
feat: add time-decay weighting to random forest model

### DIFF
--- a/tests/test_random_forest_model.py
+++ b/tests/test_random_forest_model.py
@@ -6,16 +6,82 @@ from utils.ml.random_forest import (
     construct_features_for_match,
     predict_proba,
     load_model,
+    train_model,
 )
 
 
 def _sample_df():
     data = [
-        {"Date": "2024-01-01", "HomeTeam": "A", "AwayTeam": "B", "FTHG": 1, "FTAG": 0, "FTR": "H"},
-        {"Date": "2024-01-05", "HomeTeam": "B", "AwayTeam": "A", "FTHG": 2, "FTAG": 2, "FTR": "D"},
-        {"Date": "2024-01-10", "HomeTeam": "A", "AwayTeam": "C", "FTHG": 0, "FTAG": 1, "FTR": "A"},
-        {"Date": "2024-01-15", "HomeTeam": "C", "AwayTeam": "A", "FTHG": 0, "FTAG": 3, "FTR": "A"},
-        {"Date": "2024-01-20", "HomeTeam": "A", "AwayTeam": "B", "FTHG": 2, "FTAG": 1, "FTR": "H"},
+        {
+            "Date": "2024-01-01",
+            "HomeTeam": "A",
+            "AwayTeam": "B",
+            "FTHG": 1,
+            "FTAG": 0,
+            "FTR": "H",
+            "HS": 5,
+            "AS": 4,
+            "HST": 3,
+            "AST": 2,
+            "HC": 4,
+            "AC": 3,
+        },
+        {
+            "Date": "2024-01-05",
+            "HomeTeam": "B",
+            "AwayTeam": "A",
+            "FTHG": 2,
+            "FTAG": 2,
+            "FTR": "D",
+            "HS": 7,
+            "AS": 6,
+            "HST": 4,
+            "AST": 3,
+            "HC": 5,
+            "AC": 4,
+        },
+        {
+            "Date": "2024-01-10",
+            "HomeTeam": "A",
+            "AwayTeam": "C",
+            "FTHG": 0,
+            "FTAG": 1,
+            "FTR": "A",
+            "HS": 4,
+            "AS": 5,
+            "HST": 2,
+            "AST": 3,
+            "HC": 3,
+            "AC": 4,
+        },
+        {
+            "Date": "2024-01-15",
+            "HomeTeam": "C",
+            "AwayTeam": "A",
+            "FTHG": 0,
+            "FTAG": 3,
+            "FTR": "A",
+            "HS": 6,
+            "AS": 8,
+            "HST": 1,
+            "AST": 5,
+            "HC": 2,
+            "AC": 6,
+        },
+        {
+            "Date": "2024-01-20",
+            "HomeTeam": "A",
+            "AwayTeam": "B",
+            "FTHG": 2,
+            "FTAG": 1,
+            "FTR": "H",
+            "HS": 8,
+            "AS": 7,
+            "HST": 5,
+            "AST": 3,
+            "HC": 6,
+            "AC": 5,
+        },
     ]
     df = pd.DataFrame(data)
     df["Date"] = pd.to_datetime(df["Date"])
@@ -50,3 +116,14 @@ def test_predict_proba_deterministic():
     assert sum(probs.values()) == pytest.approx(100.0)
     for p in probs.values():
         assert 0 <= p <= 100
+
+
+def test_train_model_accepts_weights(tmp_path):
+    df = pd.concat([_sample_df()] * 3, ignore_index=True)
+    df["Date"] = df["Date"] + pd.to_timedelta(df.index, unit="D")
+    csv_path = tmp_path / "sample_combined_full_updated.csv"
+    df.to_csv(csv_path, index=False)
+    model, *_ = train_model(
+        data_dir=tmp_path, n_splits=2, n_iter=1, max_samples=50, decay_factor=0.01
+    )
+    assert model is not None


### PR DESCRIPTION
## Summary
- add `decay_factor` option to `train_model` and compute exponential sample weights
- introduce `SampleWeightPipeline` so pipelines accept `sample_weight` and pass them into search and calibration
- verify weighted training with a new unit test

## Testing
- `pytest tests/test_random_forest_model.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3369679d48329bd7b42fc6057e6c5