### PR TITLE
Allow configurable alpha smoothing for random forest probabilities

### DIFF
--- a/sections/match_prediction_section.py
+++ b/sections/match_prediction_section.py
@@ -3,6 +3,7 @@ import pandas as pd
 import numpy as np
 from typing import Any, Dict, List, Tuple, Optional
 from collections.abc import Mapping
+import os
 from utils.responsive import responsive_columns
 from utils.poisson_utils import (
     expected_goals_weighted_by_elo,
@@ -104,6 +105,8 @@ def get_rf_over25_model():
 
 
 RF_O25_MODEL, RF_O25_FEATURE_NAMES, RF_O25_LABEL_ENCODER = get_rf_over25_model()
+
+PROBA_ALPHA = float(os.getenv("PROBA_ALPHA", "0.05"))
 
 @st.cache_data
 def load_upcoming_xg() -> pd.DataFrame:
@@ -538,10 +541,12 @@ def render_single_match_prediction(
     ml_probs = predict_proba(
         ml_features,
         model_data=(RF_MODEL, RF_FEATURE_NAMES, RF_LABEL_ENCODER),
+        alpha=PROBA_ALPHA,
     )
     ml_over25 = predict_over25_proba(
         ml_features,
         model_data=(RF_O25_MODEL, RF_O25_FEATURE_NAMES, RF_O25_LABEL_ENCODER),
+        alpha=PROBA_ALPHA,
     )
     use_ml = st.sidebar.toggle("Use ML probabilities", False)
     primary_outcomes = ml_probs if use_ml else outcomes

--- a/tests/test_random_forest_model.py
+++ b/tests/test_random_forest_model.py
@@ -7,7 +7,9 @@ from utils.ml.random_forest import (
     construct_features_for_match,
     predict_proba,
     load_model,
+    load_over25_model,
     train_model,
+    predict_over25_proba,
     _prepare_features,
 )
 
@@ -114,10 +116,19 @@ def test_predict_proba_deterministic():
     model_data = load_model()
     model = model_data[0]
     assert type(model).__name__ != "DummyModel"
-    probs = predict_proba(feats, model_data=model_data)
+    probs = predict_proba(feats, model_data=model_data, alpha=0.1)
     assert sum(probs.values()) == pytest.approx(100.0)
     for p in probs.values():
         assert 0 <= p <= 100
+
+
+def test_predict_over25_proba_accepts_alpha():
+    df = _sample_df()
+    elo_dict = {"A": 1600, "B": 1500}
+    feats = construct_features_for_match(df, "A", "B", elo_dict)
+    model_data = load_over25_model()
+    prob = predict_over25_proba(feats, model_data=model_data, alpha=0.1)
+    assert 0 <= prob <= 100
 
 
 def test_train_model_applies_class_weight(tmp_path):

--- a/utils/ml/random_forest.py
+++ b/utils/ml/random_forest.py
@@ -500,7 +500,11 @@ def load_model(path: str | Path = DEFAULT_MODEL_PATH):
         return model, feature_names, label_enc, params
 
 
-def predict_outcome(features: Dict[str, float], model_path: str | Path = DEFAULT_MODEL_PATH) -> str:
+def predict_outcome(
+    features: Dict[str, float],
+    model_path: str | Path = DEFAULT_MODEL_PATH,
+    alpha: float = 0.15,
+) -> str:
     """Predict match outcome using a saved model.
 
     Parameters
@@ -510,6 +514,9 @@ def predict_outcome(features: Dict[str, float], model_path: str | Path = DEFAULT
         documented above.
     model_path:
         Path to a saved model created by :func:`save_model`.
+    alpha:
+        Shrinkage factor passed to :func:`predict_proba` to dampen extreme
+        probabilities. Values closer to zero apply less shrinkage.
 
     Returns
     -------
@@ -517,10 +524,10 @@ def predict_outcome(features: Dict[str, float], model_path: str | Path = DEFAULT
         Predicted full-time result label: ``'H'`` (home win), ``'D'`` (draw) or
         ``'A'`` (away win).
     """
-    model, feature_names, label_enc, _ = load_model(model_path)
-    X = pd.DataFrame([features], columns=feature_names)
-    pred = model.predict(X)[0]
-    return label_enc.inverse_transform([pred])[0]
+    probs = predict_proba(features, model_path=model_path, alpha=alpha)
+    reverse = {"Home Win": "H", "Draw": "D", "Away Win": "A"}
+    best = max(probs, key=probs.get)
+    return reverse[best]
 
 
 def construct_features_for_match(
@@ -637,6 +644,7 @@ def predict_proba(
     features: Dict[str, float],
     model_data: Tuple[Any, Iterable[str], Any] | Tuple[Any, Iterable[str], Any, Mapping[str, Any]] | None = None,
     model_path: str | Path = DEFAULT_MODEL_PATH,
+    alpha: float = 0.15,
 ) -> Dict[str, float]:
     """Return outcome probabilities for a feature mapping.
 
@@ -650,6 +658,10 @@ def predict_proba(
         provided the model is loaded from ``model_path``.
     model_path:
         Path to the saved model, used only when ``model_data`` is ``None``.
+    alpha:
+        Shrinkage factor applied to predicted probabilities to dampen extreme
+        values. The probabilities are blended with a uniform prior using this
+        parameter.
 
     Returns
     -------
@@ -663,7 +675,6 @@ def predict_proba(
     X = _clip_features(pd.DataFrame([features], columns=feature_names))
     probs = model.predict_proba(X)[0]
     # shrink towards uniform prior to dampen extreme probabilities
-    alpha = 0.15
     probs = (1 - alpha) * probs + alpha * (1.0 / len(probs))
     probs = probs / probs.sum()
     labels = label_enc.inverse_transform(np.arange(len(probs)))
@@ -702,8 +713,22 @@ def predict_over25_proba(
     features: Dict[str, float],
     model_data: Tuple[Any, Iterable[str], Any] | None = None,
     model_path: str | Path = DEFAULT_OVER25_MODEL_PATH,
+    alpha: float = 0.15,
 ) -> float:
-    """Return the probability (0-100) that total goals exceed 2.5."""
+    """Return the probability (0-100) that total goals exceed 2.5.
+
+    Parameters
+    ----------
+    features:
+        Feature mapping produced by :func:`construct_features_for_match`.
+    model_data:
+        Optional tuple ``(model, feature_names, label_encoder)``. When not
+        provided the model is loaded from ``model_path``.
+    model_path:
+        Path to the saved model, used only when ``model_data`` is ``None``.
+    alpha:
+        Shrinkage factor applied to the over/under probability. Values closer
+        to zero apply less shrinkage toward 50%."""
     if model_data is None:
         model_data = load_over25_model(model_path)
     model, feature_names, label_enc = model_data
@@ -715,7 +740,6 @@ def predict_over25_proba(
         prob = probs[over_idx]
     else:
         prob = probs[1]
-    alpha = 0.15
     prob = (1 - alpha) * prob + alpha * 0.5
     return float(prob * 100)
 


### PR DESCRIPTION
## Summary
- add optional `alpha` smoothing parameter to `predict_proba`, `predict_over25_proba`, and `predict_outcome`
- wire through environment-driven `PROBA_ALPHA` in match prediction section (default 0.05)
- expand tests for new parameter and over/under probabilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b339e109a4832995b5ec8c606d84ea