### PR TITLE
Expose hyperparameter tuning options

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ načítá při startu, takže koeficienty jsou konzistentní napříč spuštěn
 Po přidání nové ligy nebo změně dat spusť skript výše a commitni aktualizovaný
 CSV, aby se změny propsaly i do aplikace.
 
+## 📈 Trénování modelu
+Skript `scripts/train_models.py` umožňuje trénovat a ladit Random Forest modely.
+Parametry křížové validace i rozsah vyhledávání hyperparametrů lze upravit
+pomocí argumentů příkazové řádky:
+
+```bash
+python scripts/train_models.py --n-iter 20 --n-splits 5 --recent-years 2
+```
+
+Volitelný argument `--max-samples` může omezit počet zpracovaných zápasů pro
+rychlé experimenty.
+
 ## ✅ Testy
 
 Projekt obsahuje sadu jednotkových testů. Pro jejich spuštění použij:

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -1,5 +1,7 @@
 """Train and save Random Forest models for outcome and over/under 2.5 goals."""
 
+import argparse
+
 from utils.ml.random_forest import (
     DEFAULT_MODEL_PATH,
     DEFAULT_OVER25_MODEL_PATH,
@@ -9,15 +11,31 @@ from utils.ml.random_forest import (
 )
 
 
-def main(data_dir: str = "data") -> None:
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train Random Forest models")
+    parser.add_argument("--data-dir", default="data")
+    parser.add_argument("--n-splits", type=int, default=3)
+    parser.add_argument("--recent-years", type=int, default=1)
+    parser.add_argument("--n-iter", type=int, default=1)
+    parser.add_argument("--max-samples", type=int, default=500)
+    args = parser.parse_args()
+
     model, features, le, score, params, metrics = train_model(
-        data_dir, n_splits=3, recent_years=1, n_iter=1, max_samples=500
+        args.data_dir,
+        n_splits=args.n_splits,
+        recent_years=args.recent_years,
+        n_iter=args.n_iter,
+        max_samples=args.max_samples,
     )
     save_model(model, features, le, path=DEFAULT_MODEL_PATH, best_params=params)
     print(f"Outcome model trained with score {score:.3f} and saved to {DEFAULT_MODEL_PATH}")
 
     o25_model, o25_features, o25_le, o25_score, o25_params, o25_metrics = train_over25_model(
-        data_dir, n_splits=3, recent_years=1, n_iter=1, max_samples=500
+        args.data_dir,
+        n_splits=args.n_splits,
+        recent_years=args.recent_years,
+        n_iter=args.n_iter,
+        max_samples=args.max_samples,
     )
     save_model(
         o25_model,

--- a/sections/match_prediction_section.py
+++ b/sections/match_prediction_section.py
@@ -3,6 +3,7 @@ import pandas as pd
 import numpy as np
 from typing import Any, Dict, List, Tuple, Optional
 from collections.abc import Mapping
+import os
 from utils.responsive import responsive_columns
 from utils.poisson_utils import (
     expected_goals_weighted_by_elo,
@@ -104,6 +105,8 @@ def get_rf_over25_model():
 
 
 RF_O25_MODEL, RF_O25_FEATURE_NAMES, RF_O25_LABEL_ENCODER = get_rf_over25_model()
+
+PROBA_ALPHA = float(os.getenv("PROBA_ALPHA", "0.05"))
 
 @st.cache_data
 def load_upcoming_xg() -> pd.DataFrame:
@@ -538,10 +541,12 @@ def render_single_match_prediction(
     ml_probs = predict_proba(
         ml_features,
         model_data=(RF_MODEL, RF_FEATURE_NAMES, RF_LABEL_ENCODER),
+        alpha=PROBA_ALPHA,
     )
     ml_over25 = predict_over25_proba(
         ml_features,
         model_data=(RF_O25_MODEL, RF_O25_FEATURE_NAMES, RF_O25_LABEL_ENCODER),
+        alpha=PROBA_ALPHA,
     )
     use_ml = st.sidebar.toggle("Use ML probabilities", False)
     primary_outcomes = ml_probs if use_ml else outcomes


### PR DESCRIPTION
## Summary
- allow passing custom hyperparameter search spaces to `train_model` and `train_over25_model`
- add CLI arguments to `scripts/train_models.py` for easier model tuning
- document the training script and param tuning in README
- test custom param distribution handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b339e109a4832995b5ec8c606d84ea