### PR TITLE
Add calibration diagnostics and baseline checks to RF training

### DIFF
--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -29,10 +29,15 @@ def main() -> None:
     )
     save_model(model, features, le, path=DEFAULT_MODEL_PATH, best_params=params)
     print(f"Outcome model trained with log-loss {score:.3f} and saved to {DEFAULT_MODEL_PATH}")
-    for lbl, m in metrics.items():
+    for lbl, m in metrics["per_class"].items():
         print(
-            f"  {lbl}: precision={m['precision']:.3f}, recall={m['recall']:.3f}, brier={m['brier']:.3f}"
+            f"  {lbl}: precision={m['precision']:.3f}, recall={m['recall']:.3f}, brier={m['brier']:.3f}, ece={m['ece']:.3f}"
         )
+    print("Baselines:")
+    print(f"  Frequency log-loss={metrics['baselines']['frequency_log_loss']:.3f}")
+    book_ll = metrics['baselines']['bookmaker_log_loss']
+    if book_ll is not None:
+        print(f"  Bookmaker log-loss={book_ll:.3f}")
 
     o25_model, o25_features, o25_le, o25_score, o25_params, o25_metrics = train_over25_model(
         args.data_dir,
@@ -51,10 +56,15 @@ def main() -> None:
     print(
         f"Over/Under 2.5 model trained with log-loss {o25_score:.3f} and saved to {DEFAULT_OVER25_MODEL_PATH}"
     )
-    for lbl, m in o25_metrics.items():
+    for lbl, m in o25_metrics["per_class"].items():
         print(
-            f"  {lbl}: precision={m['precision']:.3f}, recall={m['recall']:.3f}, brier={m['brier']:.3f}"
+            f"  {lbl}: precision={m['precision']:.3f}, recall={m['recall']:.3f}, brier={m['brier']:.3f}, ece={m['ece']:.3f}"
         )
+    print("Baselines:")
+    print(f"  Frequency log-loss={o25_metrics['baselines']['frequency_log_loss']:.3f}")
+    book_ll = o25_metrics['baselines']['bookmaker_log_loss']
+    if book_ll is not None:
+        print(f"  Bookmaker log-loss={book_ll:.3f}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- compute reliability curves and Expected Calibration Error for Random Forest models
- report frequency and bookmaker log-loss baselines
- surface ECE and baseline metrics in training script output

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3f099910483299a07426af6987b19