### PR TITLE
Add FBR API as xG data provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,19 @@ Expected goals values are fetched from multiple providers with the following
 priority:
 
 1. **Understat** – primary source
-2. **FBref** – fallback if Understat is unavailable
-3. **pseudo‑xG** – computed from match statistics when no external provider
+2. **FBR API** – fallback if Understat is unavailable
+3. **FBref** – final fallback when the API fails
+4. **pseudo‑xG** – computed from match statistics when no external provider
    succeeds
 
 Results are cached to JSON files in `utils/poisson_utils/xg_sources/`:
 
 - `xg_cache.json` stores the final aggregated results
-- `understat_xg_cache.json` and `fbref_xg_cache.json` keep provider‑specific
-  responses
+- `understat_xg_cache.json`, `fbrapi_xg_cache.json` and `fbref_xg_cache.json`
+  keep provider‑specific responses
+
+FBR API requests require an API key provided via the environment variable
+`FBRAPI_KEY`.
 
 Caches persist between runs. Delete the files to refresh the stored data or
 allow the scripts to overwrite them when new values are available.

--- a/tests/xg_sources/test_get_team_xg_xga.py
+++ b/tests/xg_sources/test_get_team_xg_xga.py
@@ -7,23 +7,29 @@ sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 import utils.poisson_utils.xg_sources as xg_sources
 import utils.poisson_utils.xg_sources.understat as understat_module
+import utils.poisson_utils.xg_sources.fbrapi as fbrapi_module
 import utils.poisson_utils.xg_sources.fbref as fbref_module
 from utils.poisson_utils.xg_sources import get_team_xg_xga
 
 
 def test_get_team_xg_xga_understat(monkeypatch, tmp_path):
     monkeypatch.setattr(xg_sources, "CACHE_FILE", tmp_path / "xg_cache.json")
-    calls = {"understat": 0, "fbref": 0}
+    calls = {"understat": 0, "fbrapi": 0, "fbref": 0}
 
     def fake_understat(team, season):
         calls["understat"] += 1
         return {"xg": 1.2, "xga": 0.9}
+
+    def fake_fbrapi(team, season):
+        calls["fbrapi"] += 1
+        return {"xg": 0.7, "xga": 1.0}
 
     def fake_fbref(team, season):
         calls["fbref"] += 1
         return {"xg": 0.5, "xga": 0.6}
 
     monkeypatch.setattr(understat_module, "get_team_xg_xga", fake_understat)
+    monkeypatch.setattr(fbrapi_module, "get_team_xg_xga", fake_fbrapi)
     monkeypatch.setattr(fbref_module, "get_team_xg_xga", fake_fbref)
 
     data = get_team_xg_xga("Test", "2020")
@@ -31,22 +37,57 @@ def test_get_team_xg_xga_understat(monkeypatch, tmp_path):
     assert data["xg"] == pytest.approx(1.2)
     assert data["xga"] == pytest.approx(0.9)
     assert calls["understat"] == 1
+    assert calls["fbrapi"] == 0
+    assert calls["fbref"] == 0
+
+
+def test_get_team_xg_xga_fbrapi_fallback(monkeypatch, tmp_path):
+    monkeypatch.setattr(xg_sources, "CACHE_FILE", tmp_path / "xg_cache.json")
+    calls = {"understat": 0, "fbrapi": 0, "fbref": 0}
+
+    def fail_understat(team, season):
+        calls["understat"] += 1
+        raise RuntimeError("fail")
+
+    def fbrapi_success(team, season):
+        calls["fbrapi"] += 1
+        return {"xg": 0.7, "xga": 1.0}
+
+    def fake_fbref(team, season):
+        calls["fbref"] += 1
+        return {"xg": 0.5, "xga": 0.6}
+
+    monkeypatch.setattr(understat_module, "get_team_xg_xga", fail_understat)
+    monkeypatch.setattr(fbrapi_module, "get_team_xg_xga", fbrapi_success)
+    monkeypatch.setattr(fbref_module, "get_team_xg_xga", fake_fbref)
+
+    data = get_team_xg_xga("Test", "2020")
+    assert data["source"] == "fbrapi"
+    assert data["xg"] == pytest.approx(0.7)
+    assert data["xga"] == pytest.approx(1.0)
+    assert calls["understat"] == 1
+    assert calls["fbrapi"] == 1
     assert calls["fbref"] == 0
 
 
 def test_get_team_xg_xga_fbref_fallback(monkeypatch, tmp_path):
     monkeypatch.setattr(xg_sources, "CACHE_FILE", tmp_path / "xg_cache.json")
-    calls = {"understat": 0, "fbref": 0}
+    calls = {"understat": 0, "fbrapi": 0, "fbref": 0}
 
     def fail_understat(team, season):
         calls["understat"] += 1
         raise RuntimeError("fail")
+
+    def fail_fbrapi(team, season):
+        calls["fbrapi"] += 1
+        raise RuntimeError("fail fbrapi")
 
     def fbref_success(team, season):
         calls["fbref"] += 1
         return {"xg": 0.8, "xga": 1.1}
 
     monkeypatch.setattr(understat_module, "get_team_xg_xga", fail_understat)
+    monkeypatch.setattr(fbrapi_module, "get_team_xg_xga", fail_fbrapi)
     monkeypatch.setattr(fbref_module, "get_team_xg_xga", fbref_success)
 
     data = get_team_xg_xga("Test", "2020")
@@ -54,4 +95,5 @@ def test_get_team_xg_xga_fbref_fallback(monkeypatch, tmp_path):
     assert data["xg"] == pytest.approx(0.8)
     assert data["xga"] == pytest.approx(1.1)
     assert calls["understat"] == 1
+    assert calls["fbrapi"] == 1
     assert calls["fbref"] == 1

--- a/utils/poisson_utils/xg_sources/__init__.py
+++ b/utils/poisson_utils/xg_sources/__init__.py
@@ -41,13 +41,13 @@ def get_team_xg_xga(
 ) -> Dict[str, Any]:
     """Return team xG and xGA for a season from available providers.
 
-    Providers are queried in order: ``understat`` and ``fbref``.  If both
-    fail and ``league_df`` is provided, pseudo-xG values computed from the
-    dataframe are used. Results are cached on disk to avoid repeated network
-    calls.
+    Providers are queried in order: ``understat``, ``fbrapi`` and ``fbref``.
+    If all fail and ``league_df`` is provided, pseudo-xG values computed from
+    the dataframe are used. Results are cached on disk to avoid repeated
+    network calls.
     """
     cache = _load_cache()
-    for source in ("understat", "fbref"):
+    for source in ("understat", "fbrapi", "fbref"):
         key = f"{season}|{team}|{source}"
         if key in cache:
             data = cache[key]

--- a/utils/poisson_utils/xg_sources/fbrapi.py
+++ b/utils/poisson_utils/xg_sources/fbrapi.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Dict, Optional
+
+import requests
+
+CACHE_FILE = Path(__file__).with_name("fbrapi_xg_cache.json")
+
+
+def _load_cache() -> Dict[str, Dict[str, float]]:
+    if CACHE_FILE.exists():
+        try:
+            with CACHE_FILE.open("r", encoding="utf-8") as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def _save_cache(cache: Dict[str, Dict[str, float]]) -> None:
+    with CACHE_FILE.open("w", encoding="utf-8") as f:
+        json.dump(cache, f)
+
+
+def fetch_fbrapi_team_xg(team: str, season: str) -> Optional[Dict[str, float]]:
+    """Fetch xG and xGA for a team from the FBR API.
+
+    Returns a dictionary with keys ``xg`` and ``xga`` if available,
+    otherwise ``None``.
+    """
+    api_key = os.getenv("FBRAPI_KEY")
+    if not api_key:
+        return None
+
+    cache = _load_cache()
+    cache_key = f"{season}|{team}"
+    if cache_key in cache:
+        return cache[cache_key]
+
+    url = "https://fbrapi.com/api/xg"
+    params = {"team": team, "season": season, "api_key": api_key}
+    try:
+        resp = requests.get(url, params=params, timeout=10)
+        if resp.status_code != 200:
+            return None
+        data = resp.json()
+    except Exception:
+        return None
+
+    if "xg" in data and "xga" in data:
+        result = {"xg": float(data["xg"]), "xga": float(data["xga"])}
+        cache[cache_key] = result
+        _save_cache(cache)
+        return result
+    return None
+
+
+def get_team_xg_xga(team: str, season: str) -> Dict[str, float]:
+    """Return team xG and xGA fetched from the FBR API."""
+    return fetch_fbrapi_team_xg(team, season) or {}
+


### PR DESCRIPTION
## Summary
- add FBR API provider module for team xG and xGA
- query new provider before existing fbref fallback
- document and test FBR API provider usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b72476f5c48329800a1c981ec79354