### PR TITLE
Add FBR API key management and lightweight Random Forest utilities

### DIFF
--- a/fbrapi_dataset.py
+++ b/fbrapi_dataset.py
@@ -1,0 +1,251 @@
+"""Utilities for downloading match data from the FBR API.
+
+The original repository expected a module named ``fbrapi_dataset`` that could
+build a training dataset for the Random Forest model. This file provides that
+functionality and integrates automatic API key handling so that the key is
+generated only once and then cached locally.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+import numpy as np
+import pandas as pd
+import requests
+
+from utils.poisson_utils.xg_sources.fbrapi import get_fbrapi_api_key
+
+
+BASE = "https://fbrapi.com"
+API_KEY = get_fbrapi_api_key()
+HDRS = {"X-API-Key": API_KEY} if API_KEY else {}
+SLEEP = 3.3  # ~1 request / 3 s
+RETRIES = 3
+CACHE_DIR = Path("cache_fbrapi")
+CACHE_DIR.mkdir(exist_ok=True)
+
+
+def _cached_json(filename: str) -> Dict[str, Any] | None:
+    p = CACHE_DIR / filename
+    if p.exists():
+        try:
+            return json.loads(p.read_text(encoding="utf-8"))
+        except Exception:
+            return None
+    return None
+
+
+def _save_cache(filename: str, data: Dict[str, Any]) -> None:
+    (CACHE_DIR / filename).write_text(json.dumps(data), encoding="utf-8")
+
+
+def _get(path: str, params: Dict[str, Any] | None = None, cache_key: str | None = None) -> Dict[str, Any]:
+    if cache_key:
+        cached = _cached_json(cache_key)
+        if cached is not None:
+            return cached
+
+    if not API_KEY:
+        raise RuntimeError("Missing FBR API key; call get_fbrapi_api_key() first")
+
+    url = f"{BASE}{path}"
+    last_exc: Exception | None = None
+    for _ in range(RETRIES):
+        try:
+            r = requests.get(url, params=params or {}, headers=HDRS, timeout=60)
+            if r.status_code == 429:
+                time.sleep(max(SLEEP, 3.0))
+                continue
+            r.raise_for_status()
+            data = r.json()
+            if cache_key:
+                _save_cache(cache_key, data)
+            time.sleep(SLEEP)
+            return data
+        except Exception as e:  # pragma: no cover - network failure
+            last_exc = e
+            time.sleep(SLEEP)
+    raise RuntimeError(f"FBR API failed: {url} params={params} err={last_exc}")
+
+
+def fetch_teams(league_id: int, season_id: str) -> pd.DataFrame:
+    data = _get(
+        "/teams",
+        {"league_id": league_id, "season_id": season_id},
+        cache_key=f"teams_{league_id}_{season_id}.json",
+    )
+    df = pd.DataFrame(data.get("data", []))
+    cols = [c for c in ["team", "team_id"] if c in df.columns]
+    return df[cols].drop_duplicates()
+
+
+def fetch_matches(league_id: int, season_id: str) -> pd.DataFrame:
+    data = _get(
+        "/matches",
+        {"league_id": league_id, "season_id": season_id},
+        cache_key=f"matches_{league_id}_{season_id}.json",
+    )
+    df = pd.DataFrame(data.get("data", []))
+    if "date" in df.columns:
+        df["date"] = pd.to_datetime(df["date"], errors="coerce", utc=True).dt.tz_localize(None)
+    df["season_id"] = season_id
+    return df
+
+
+def fetch_team_match_stats(team_id: int, league_id: int, season_id: str) -> pd.DataFrame:
+    data = _get(
+        "/team-match-stats",
+        {"team_id": team_id, "league_id": league_id, "season_id": season_id},
+        cache_key=f"teamstats_{team_id}_{league_id}_{season_id}.json",
+    )
+    df = pd.DataFrame(data.get("data", []))
+    for c in [
+        "match_id",
+        "date",
+        "team_id",
+        "opponent_id",
+        "team",
+        "gf",
+        "ga",
+        "xg",
+        "xga",
+        "shots",
+        "sot",
+        "poss",
+        "home_away",
+    ]:
+        if c not in df.columns:
+            df[c] = np.nan
+    df["date"] = pd.to_datetime(df["date"], errors="coerce", utc=True).dt.tz_localize(None)
+    df["season_id"] = season_id
+    return df[
+        [
+            "match_id",
+            "date",
+            "season_id",
+            "team_id",
+            "opponent_id",
+            "team",
+            "gf",
+            "ga",
+            "xg",
+            "xga",
+            "shots",
+            "sot",
+            "poss",
+            "home_away",
+        ]
+    ]
+
+
+def _assemble_one_season(league_id: int, season_id: str) -> pd.DataFrame:
+    teams = fetch_teams(league_id, season_id)
+    stats = []
+    for _, t in teams.iterrows():
+        tid = int(t["team_id"])
+        stats.append(fetch_team_match_stats(tid, league_id, season_id))
+    stats = pd.concat(stats, ignore_index=True)
+
+    home = stats[stats["home_away"].astype(str).str.lower().eq("home")].copy()
+    away = stats[stats["home_away"].astype(str).str.lower().eq("away")].copy()
+
+    h = home.rename(columns=lambda c: f"{c}_H" if c not in ["match_id", "date", "season_id"] else c)
+    a = away.rename(columns=lambda c: f"{c}_A" if c not in ["match_id", "date", "season_id"] else c)
+    Xdf = h.merge(a, on=["match_id", "date", "season_id"], how="inner")
+
+    Xdf["goals_total"] = Xdf["gf_H"].astype(float) + Xdf["gf_A"].astype(float)
+    Xdf["over25"] = (Xdf["goals_total"] > 2).astype(int)
+    Xdf["outcome"] = np.select(
+        [Xdf["gf_H"] > Xdf["gf_A"], Xdf["gf_H"] < Xdf["gf_A"]],
+        ["H", "A"],
+        default="D",
+    )
+    return Xdf
+
+
+def build_three_seasons(league_id: int, seasons: Iterable[str]) -> pd.DataFrame:
+    parts = [_assemble_one_season(league_id, s) for s in seasons]
+    df = pd.concat(parts, ignore_index=True).sort_values("date").reset_index(drop=True)
+
+    def add_roll(df_in: pd.DataFrame, side: str, window: int = 5) -> pd.DataFrame:
+        df = df_in.sort_values("date").copy()
+        team_col = f"team_id_{side}"
+        if team_col not in df.columns:
+            df[team_col] = np.nan
+        grp = df.groupby(team_col, dropna=False)
+        for base in ["xg", "xga", "shots", "sot", "gf", "ga", "poss"]:
+            c = f"{base}_{side}"
+            if c not in df.columns:
+                df[c] = np.nan
+            r = grp[c].rolling(window, min_periods=max(3, window // 2)).mean().reset_index(level=0, drop=True)
+            df[f"{base}_roll{window}_{side}"] = r.shift(1)
+        return df
+
+    for side in ["H", "A"]:
+        df = add_roll(df, side, window=5)
+
+    def compute_time_weights(dates: pd.Series, half_life_days: int = 240) -> np.ndarray:
+        max_d = pd.to_datetime(dates).max()
+        age = (max_d - pd.to_datetime(dates)).dt.days.clip(lower=0).astype(float)
+        lam = np.log(2) / max(half_life_days, 1)
+        w = np.exp(-lam * age)
+        return (w / (w.mean() if w.mean() > 0 else 1.0)).values
+
+    df["sample_weight"] = compute_time_weights(df["date"], half_life_days=240)
+
+    keep = [
+        "match_id",
+        "date",
+        "season_id",
+        "team_id_H",
+        "team_H",
+        "opponent_id_H",
+        "team_id_A",
+        "team_A",
+        "opponent_id_A",
+        "xg_H",
+        "xga_H",
+        "shots_H",
+        "sot_H",
+        "gf_H",
+        "ga_H",
+        "poss_H",
+        "xg_A",
+        "xga_A",
+        "shots_A",
+        "sot_A",
+        "gf_A",
+        "ga_A",
+        "poss_A",
+        "xg_roll5_H",
+        "xga_roll5_H",
+        "shots_roll5_H",
+        "sot_roll5_H",
+        "gf_roll5_H",
+        "ga_roll5_H",
+        "poss_roll5_H",
+        "xg_roll5_A",
+        "xga_roll5_A",
+        "shots_roll5_A",
+        "sot_roll5_A",
+        "gf_roll5_A",
+        "ga_roll5_A",
+        "poss_roll5_A",
+        "over25",
+        "outcome",
+        "sample_weight",
+    ]
+    return df[keep].copy()
+
+
+__all__ = [
+    "fetch_teams",
+    "fetch_matches",
+    "fetch_team_match_stats",
+    "build_three_seasons",
+]
+

--- a/tests/xg_sources/test_fbrapi_api_key.py
+++ b/tests/xg_sources/test_fbrapi_api_key.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+import types
+import requests
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+import utils.poisson_utils.xg_sources.fbrapi as fbrapi_module
+
+
+def test_api_key_cached(monkeypatch, tmp_path):
+    calls = {"post": 0}
+
+    def fake_post(url, timeout=10):
+        calls["post"] += 1
+        class Resp:
+            status_code = 200
+            def json(self):
+                return {"api_key": "TESTKEY"}
+            def raise_for_status(self):
+                pass
+        return Resp()
+
+    monkeypatch.setattr(fbrapi_module, "API_KEY_FILE", tmp_path / "key.txt")
+    monkeypatch.setattr(fbrapi_module.requests, "post", fake_post)
+    monkeypatch.delenv("FBRAPI_KEY", raising=False)
+
+    key1 = fbrapi_module.get_fbrapi_api_key()
+    key2 = fbrapi_module.get_fbrapi_api_key()
+
+    assert key1 == "TESTKEY"
+    assert key2 == "TESTKEY"
+    assert calls["post"] == 1

--- a/utils/poisson_utils/xg_sources/fbref.py
+++ b/utils/poisson_utils/xg_sources/fbref.py
@@ -1,144 +1,98 @@
-# fbrapi_dataset.py
+"""Retrieve team expected goals data from FBref.
+
+The real FBref website contains a wealth of statistics.  For the purposes of
+this project we only need a tiny subset – the season totals for xG and xGA for a
+single team.  The data is cached on disk so repeated calls for the same team do
+not hit the network.
+"""
+
 from __future__ import annotations
-import time, json
+
+import json
 from pathlib import Path
-from typing import Dict, Any, List, Iterable, Tuple
-import numpy as np
-import pandas as pd
+from typing import Dict, Optional
+from urllib import robotparser
+
 import requests
+from bs4 import BeautifulSoup
 
-BASE = "https://fbrapi.com"
-API_KEY = "PASTE_YOUR_API_KEY_HERE"   # <--- DOPLŇ
-HDRS = {"X-API-Key": API_KEY}
-SLEEP = 3.3          # ~1 request / 3 s
-RETRIES = 3
-CACHE_DIR = Path("cache_fbrapi"); CACHE_DIR.mkdir(exist_ok=True)
+CACHE_FILE = Path(__file__).with_name("fbref_xg_cache.json")
 
-def _cached_json(filename: str) -> Dict[str, Any] | None:
-    p = CACHE_DIR / filename
-    if p.exists():
-        try: return json.loads(p.read_text(encoding="utf-8"))
-        except Exception: return None
+
+def _load_cache() -> Dict[str, Dict[str, float]]:
+    if CACHE_FILE.exists():
+        try:
+            return json.loads(CACHE_FILE.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def _save_cache(cache: Dict[str, Dict[str, float]]) -> None:
+    CACHE_FILE.write_text(json.dumps(cache), encoding="utf-8")
+
+
+def fetch_fbref_team_xg(team: str, season: str, league_code: str) -> Optional[Dict[str, float]]:
+    """Return average xG and xGA per game for ``team`` in ``season``.
+
+    The function respects the site's robots.txt and stores results in
+    ``CACHE_FILE`` so subsequent calls are served from disk.
+    """
+
+    cache = _load_cache()
+    key = f"{season}|{league_code}|{team}"
+    if key in cache:
+        return cache[key]
+
+    url = f"https://fbref.com/en/comps/{league_code}/{season}"
+
+    rp = robotparser.RobotFileParser()
+    try:
+        rp.set_url("https://fbref.com/robots.txt")
+        rp.read()
+        if not rp.can_fetch("*", url):
+            return None
+    except Exception:
+        return None
+
+    try:
+        resp = requests.get(url, headers={"User-Agent": "Mozilla/5.0"}, timeout=10)
+        if resp.status_code != 200:
+            return None
+        soup = BeautifulSoup(resp.text, "html.parser")
+    except Exception:
+        return None
+
+    table = soup.find("table", id="stats")
+    if table is None:
+        return None
+
+    for row in table.find_all("tr"):
+        th = row.find("th", {"data-stat": "team"})
+        if th is None:
+            continue
+        name = th.get_text(strip=True)
+        if name.lower() != team.lower():
+            continue
+        try:
+            games = float(row.find("td", {"data-stat": "games"}).get_text(strip=True))
+            xg_for = float(row.find("td", {"data-stat": "xg_for"}).get_text(strip=True))
+            xg_against = float(row.find("td", {"data-stat": "xg_against"}).get_text(strip=True))
+        except Exception:
+            return None
+        games = games or 1.0
+        xg = xg_for / games
+        xga = xg_against / games
+        result = {"xg": xg, "xga": xga}
+        cache[key] = result
+        _save_cache(cache)
+        return result
     return None
 
-def _save_cache(filename: str, data: Dict[str, Any]) -> None:
-    (CACHE_DIR / filename).write_text(json.dumps(data), encoding="utf-8")
 
-def _get(path: str, params: Dict[str, Any] | None = None, cache_key: str | None = None) -> Dict[str, Any]:
-    if cache_key:
-        c = _cached_json(cache_key)
-        if c is not None: return c
-    url = f"{BASE}{path}"; last_exc = None
-    for _ in range(RETRIES):
-        try:
-            r = requests.get(url, params=params or {}, headers=HDRS, timeout=60)
-            if r.status_code == 429:
-                time.sleep(max(SLEEP, 3.0)); continue
-            r.raise_for_status()
-            data = r.json()
-            if cache_key: _save_cache(cache_key, data)
-            time.sleep(SLEEP)
-            return data
-        except Exception as e:
-            last_exc = e; time.sleep(SLEEP)
-    raise RuntimeError(f"FBR API failed: {url} params={params} err={last_exc}")
+def get_team_xg_xga(team: str, season: str, league_code: str) -> Dict[str, float]:
+    """Public wrapper used by the provider chain."""
+    return fetch_fbref_team_xg(team, season, league_code) or {}
 
-def fetch_teams(league_id: int, season_id: str) -> pd.DataFrame:
-    data = _get("/teams", {"league_id": league_id, "season_id": season_id},
-                cache_key=f"teams_{league_id}_{season_id}.json")
-    df = pd.DataFrame(data.get("data", []))
-    cols = [c for c in ["team","team_id"] if c in df.columns]
-    return df[cols].drop_duplicates()
 
-def fetch_matches(league_id: int, season_id: str) -> pd.DataFrame:
-    data = _get("/matches", {"league_id": league_id, "season_id": season_id},
-                cache_key=f"matches_{league_id}_{season_id}.json")
-    df = pd.DataFrame(data.get("data", []))
-    if "date" in df.columns:
-        df["date"] = pd.to_datetime(df["date"], errors="coerce", utc=True).dt.tz_localize(None)
-    df["season_id"] = season_id
-    return df
-
-def fetch_team_match_stats(team_id: int, league_id: int, season_id: str) -> pd.DataFrame:
-    data = _get("/team-match-stats",
-                {"team_id": team_id, "league_id": league_id, "season_id": season_id},
-                cache_key=f"teamstats_{team_id}_{league_id}_{season_id}.json")
-    df = pd.DataFrame(data.get("data", []))
-    for c in ["match_id","date","team_id","opponent_id","team","gf","ga","xg","xga","shots","sot","poss","home_away"]:
-        if c not in df.columns: df[c] = np.nan
-    df["date"] = pd.to_datetime(df["date"], errors="coerce", utc=True).dt.tz_localize(None)
-    df["season_id"] = season_id
-    return df[["match_id","date","season_id","team_id","opponent_id","team","gf","ga","xg","xga","shots","sot","poss","home_away"]]
-
-def _assemble_one_season(league_id: int, season_id: str) -> pd.DataFrame:
-    teams = fetch_teams(league_id, season_id)
-    stats = []
-    for _, t in teams.iterrows():
-        tid = int(t["team_id"])
-        stats.append(fetch_team_match_stats(tid, league_id, season_id))
-    stats = pd.concat(stats, ignore_index=True)
-
-    # rozdělení na HOME/AWAY podle home_away flagu
-    home = stats[stats["home_away"].astype(str).str.lower().eq("home")].copy()
-    away = stats[stats["home_away"].astype(str).str.lower().eq("away")].copy()
-
-    h = home.rename(columns=lambda c: f"{c}_H" if c not in ["match_id","date","season_id"] else c)
-    a = away.rename(columns=lambda c: f"{c}_A" if c not in ["match_id","date","season_id"] else c)
-    Xdf = h.merge(a, on=["match_id","date","season_id"], how="inner")
-
-    # cílovky
-    Xdf["goals_total"] = Xdf["gf_H"].astype(float) + Xdf["gf_A"].astype(float)
-    Xdf["over25"] = (Xdf["goals_total"] > 2).astype(int)
-    Xdf["outcome"] = np.select(
-        [Xdf["gf_H"] > Xdf["gf_A"], Xdf["gf_H"] < Xdf["gf_A"]],
-        ["H","A"],
-        default="D"
-    )
-    return Xdf
-
-def build_three_seasons(league_id: int, seasons: Iterable[str]) -> pd.DataFrame:
-    parts = [ _assemble_one_season(league_id, s) for s in seasons ]
-    df = pd.concat(parts, ignore_index=True).sort_values("date").reset_index(drop=True)
-
-    # Rolling featury bez leakage – zvlášť pro H a A
-    def add_roll(df_in: pd.DataFrame, side: str, window: int = 5) -> pd.DataFrame:
-        df = df_in.sort_values("date").copy()
-        team_col = f"team_id_{side}"
-        if team_col not in df.columns:
-            df[team_col] = np.nan
-        grp = df.groupby(team_col, dropna=False)
-        for base in ["xg","xga","shots","sot","gf","ga","poss"]:
-            c = f"{base}_{side}"
-            if c not in df.columns: df[c] = np.nan
-            r = grp[c].rolling(window, min_periods=max(3, window//2)).mean().reset_index(level=0, drop=True)
-            df[f"{base}_roll{window}_{side}"] = r.shift(1)
-        return df
-
-    for side in ["H","A"]:
-        df = add_roll(df, side, window=5)
-
-    # Sample weights podle stáří – exponenciální útlum
-    # w = 0.5 po 'half_life_days' dnech vůči nejnovějšímu zápasu (default 240 ~ 8 měsíců)
-    def compute_time_weights(dates: pd.Series, half_life_days: int = 240) -> np.ndarray:
-        max_d = pd.to_datetime(dates).max()
-        age = (max_d - pd.to_datetime(dates)).dt.days.clip(lower=0).astype(float)
-        lam = np.log(2) / max(half_life_days, 1)
-        w = np.exp(-lam * age)
-        # škálování na průměr 1 (volitelné)
-        return (w / (w.mean() if w.mean() > 0 else 1.0)).values
-
-    df["sample_weight"] = compute_time_weights(df["date"], half_life_days=240)
-
-    # sloupce k ponechání (featury + cílovky + identifikace)
-    keep = [
-        "match_id","date","season_id","team_id_H","team_H","opponent_id_H",
-        "team_id_A","team_A","opponent_id_A",
-        # raw
-        "xg_H","xga_H","shots_H","sot_H","gf_H","ga_H","poss_H",
-        "xg_A","xga_A","shots_A","sot_A","gf_A","ga_A","poss_A",
-        # rolling
-        "xg_roll5_H","xga_roll5_H","shots_roll5_H","sot_roll5_H","gf_roll5_H","ga_roll5_H","poss_roll5_H",
-        "xg_roll5_A","xga_roll5_A","shots_roll5_A","sot_roll5_A","gf_roll5_A","ga_roll5_A","poss_roll5_A",
-        # targets & weights
-        "over25","outcome","sample_weight"
-    ]
+__all__ = ["fetch_fbref_team_xg", "get_team_xg_xga"]


### PR DESCRIPTION
## Summary
- Add automatic FBR API key generation and caching to avoid repeated authentication requests
- Provide minimal Random Forest helper module that loads pretrained models and constructs features
- Implement FBref xG provider with local caching and HTML parsing
- Add dataset builder and regression test for API key caching

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b730085dc0832980175ea9a3c1c6a7