### PR TITLE
Expand match feature construction

### DIFF
--- a/utils/ml/random_forest.py
+++ b/utils/ml/random_forest.py
@@ -40,6 +40,17 @@ def load_model(path: str | Path = DEFAULT_MODEL_PATH) -> Tuple[Any, Iterable[str
             "away_recent_form",
             "elo_diff",
             "xg_diff",
+            "xga_diff",
+            "home_conceded",
+            "away_conceded",
+            "conceded_diff",
+            "shots_diff",
+            "shot_target_diff",
+            "poss_diff",
+            "home_advantage",
+            "days_since_last_match",
+            "attack_strength_diff",
+            "defense_strength_diff",
         ], SimpleLabelEncoder()
 
 
@@ -57,6 +68,17 @@ def load_over25_model(
             "away_recent_form",
             "elo_diff",
             "xg_diff",
+            "xga_diff",
+            "home_conceded",
+            "away_conceded",
+            "conceded_diff",
+            "shots_diff",
+            "shot_target_diff",
+            "poss_diff",
+            "home_advantage",
+            "days_since_last_match",
+            "attack_strength_diff",
+            "defense_strength_diff",
         ], SimpleLabelEncoder()
 
 
@@ -66,25 +88,104 @@ def construct_features_for_match(
     away_team: str,
     elo_dict: Dict[str, float],
 ) -> Dict[str, float]:
-    """Construct a minimal feature mapping for a single match.
+    """Construct feature mapping for a single match from FBR stats.
 
-    The implementation here is intentionally lightweight; it provides sane
-    defaults and only a couple of simple signals so that the helpers can be
-    used without requiring the full training pipeline.
+    The function operates on a DataFrame in the shape produced by
+    :mod:`fbrapi_dataset` (``team_H``, ``team_A`` etc.) and calculates
+    lightweight rolling metrics for the two sides.  Only a small subset of the
+    full training pipeline is implemented so the app can work with minimal
+    historical data.
     """
 
+    df = df.copy()
+    date_col = "date" if "date" in df.columns else "Date"
+    df[date_col] = pd.to_datetime(df[date_col], errors="coerce")
+    df.sort_values(date_col, inplace=True)
+
+    def recent_form(team: str) -> float:
+        tm = df[(df.get("team_H") == team) | (df.get("team_A") == team)].tail(5)
+        vals: list[float] = []
+        for _, r in tm.iterrows():
+            if r.get("team_H") == team:
+                gf, ga = r.get("gf_H", 0), r.get("ga_H", 0)
+            else:
+                gf, ga = r.get("gf_A", 0), r.get("ga_A", 0)
+            vals.append(1 if gf > ga else 0 if gf == ga else -1)
+        return float(np.mean(vals)) if vals else 0.0
+
+    def rolling_avg(team: str, col_home: str, col_away: str) -> float:
+        tm = df[(df.get("team_H") == team) | (df.get("team_A") == team)].tail(5)
+        vals: list[float] = []
+        for _, r in tm.iterrows():
+            vals.append(r.get(col_home, 0.0) if r.get("team_H") == team else r.get(col_away, 0.0))
+        return float(np.mean(vals)) if vals else 0.0
+
+    def last_match_date(team: str) -> pd.Timestamp | None:
+        tm = df[(df.get("team_H") == team) | (df.get("team_A") == team)]
+        return None if tm.empty else tm[date_col].max()
+
+    home_form = recent_form(home_team)
+    away_form = recent_form(away_team)
+
+    home_xg = rolling_avg(home_team, "xg_H", "xg_A")
+    away_xg = rolling_avg(away_team, "xg_H", "xg_A")
+    xg_diff = home_xg - away_xg
+
+    home_xga = rolling_avg(home_team, "xga_H", "xga_A")
+    away_xga = rolling_avg(away_team, "xga_H", "xga_A")
+    xga_diff = home_xga - away_xga
+
+    home_conc = rolling_avg(home_team, "ga_H", "ga_A")
+    away_conc = rolling_avg(away_team, "ga_H", "ga_A")
+    conceded_diff = home_conc - away_conc
+
+    shots_diff = rolling_avg(home_team, "shots_H", "shots_A") - rolling_avg(away_team, "shots_H", "shots_A")
+    shot_target_diff = rolling_avg(home_team, "sot_H", "sot_A") - rolling_avg(away_team, "sot_H", "sot_A")
+    poss_diff = rolling_avg(home_team, "poss_H", "poss_A") - rolling_avg(away_team, "poss_H", "poss_A")
+
+    h_last = last_match_date(home_team)
+    a_last = last_match_date(away_team)
+    days_since_last = float((h_last - a_last).days) if h_last and a_last else 0.0
+
+    attack_strength_diff = 0.0
+    defense_strength_diff = 0.0
+    try:  # pragma: no cover - optional dependency
+        from utils.poisson_utils.stats import calculate_team_strengths
+
+        tmp = df[[date_col, "team_H", "team_A", "gf_H", "gf_A"]].rename(
+            columns={
+                date_col: "Date",
+                "team_H": "HomeTeam",
+                "team_A": "AwayTeam",
+                "gf_H": "FTHG",
+                "gf_A": "FTAG",
+            }
+        )
+        atk, dfn, _ = calculate_team_strengths(tmp)
+        attack_strength_diff = atk.get(home_team, 0.0) - atk.get(away_team, 0.0)
+        defense_strength_diff = dfn.get(home_team, 0.0) - dfn.get(away_team, 0.0)
+    except Exception:
+        pass
+
     features = {
-        "home_recent_form": 0.0,
-        "away_recent_form": 0.0,
+        "home_recent_form": home_form,
+        "away_recent_form": away_form,
         "elo_diff": float(elo_dict.get(home_team, 1500) - elo_dict.get(away_team, 1500)),
-        "xg_diff": 0.0,
-        "home_conceded": 0.0,
-        "away_conceded": 0.0,
-        "conceded_diff": 0.0,
+        "xg_diff": xg_diff,
+        "xga_diff": xga_diff,
+        "home_conceded": home_conc,
+        "away_conceded": away_conc,
+        "conceded_diff": conceded_diff,
+        "shots_diff": shots_diff,
+        "shot_target_diff": shot_target_diff,
+        "poss_diff": poss_diff,
+        # ``corners_diff`` retained for compatibility; possession data is a better
+        # proxy in the FBR dataset so corners are not available.
+        "corners_diff": 0.0,
         "home_advantage": 1.0,
-        "days_since_last_match": 0.0,
-        "attack_strength_diff": 0.0,
-        "defense_strength_diff": 0.0,
+        "days_since_last_match": days_since_last,
+        "attack_strength_diff": attack_strength_diff,
+        "defense_strength_diff": defense_strength_diff,
     }
     return features
 


### PR DESCRIPTION
## Summary
- Compute rolling form, xG/xGA, conceded, shot, and possession features for a match from FBR stats
- Expose elo_diff and additional metrics in feature dictionary
- Update fallback feature names for Random Forest models

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b73a4e81588329acae80532ff5fdb0