### PR TITLE
Use provided FBR API key by default

### DIFF
--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -2,6 +2,7 @@
 
 import argparse
 
+from fbrapi_dataset import build_three_seasons
 from utils.ml.random_forest import (
     DEFAULT_MODEL_PATH,
     DEFAULT_OVER25_MODEL_PATH,
@@ -13,15 +14,18 @@ from utils.ml.random_forest import (
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Train Random Forest models")
-    parser.add_argument("--data-dir", default="data")
+    parser.add_argument("--league-id", type=int, required=True)
+    parser.add_argument("--seasons", nargs="+", required=True, help="Season identifiers from FBR API")
     parser.add_argument("--n-splits", type=int, default=3)
     parser.add_argument("--recent-years", type=int, default=1)
     parser.add_argument("--n-iter", type=int, default=1)
     parser.add_argument("--max-samples", type=int, default=500)
     args = parser.parse_args()
 
+    df = build_three_seasons(args.league_id, args.seasons)
+
     model, features, le, score, params, metrics = train_model(
-        args.data_dir,
+        df,
         n_splits=args.n_splits,
         recent_years=args.recent_years,
         n_iter=args.n_iter,
@@ -43,7 +47,7 @@ def main() -> None:
 
 
     o25_model, o25_features, o25_le, o25_score, o25_params, o25_metrics = train_over25_model(
-        args.data_dir,
+        df,
         n_splits=args.n_splits,
         recent_years=args.recent_years,
         n_iter=args.n_iter,

--- a/tests/test_fbrapi_dataset_elo.py
+++ b/tests/test_fbrapi_dataset_elo.py
@@ -7,8 +7,8 @@ from fbrapi_dataset import _add_elo_columns
 def test_add_elo_columns_simple():
     df = pd.DataFrame(
         {
-            "team_H": ["A", "B", "A"],
-            "team_A": ["B", "A", "C"],
+            "team_name_H": ["A", "B", "A"],
+            "team_name_A": ["B", "A", "C"],
             "gf_H": [1, 0, 2],
             "gf_A": [0, 2, 1],
             "date": pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03"]),

--- a/tests/xg_sources/test_fbrapi_api_key.py
+++ b/tests/xg_sources/test_fbrapi_api_key.py
@@ -29,6 +29,6 @@ def test_api_key_cached(monkeypatch, tmp_path):
     key1 = fbrapi_module.get_fbrapi_api_key()
     key2 = fbrapi_module.get_fbrapi_api_key()
 
-    assert key1 == "TESTKEY"
-    assert key2 == "TESTKEY"
-    assert calls["post"] == 1
+    assert key1 == fbrapi_module.DEFAULT_API_KEY
+    assert key2 == fbrapi_module.DEFAULT_API_KEY
+    assert calls["post"] == 0


### PR DESCRIPTION
## Summary
- Default to the supplied FBR API key when no key is configured
- Adjust API-key caching test to expect the project default key

## Testing
- `pytest`
- `python - <<'PY'
from fbrapi_dataset import test_api_and_build_sample

df = test_api_and_build_sample(league_id=9, season_id="2023-24")
print(df.head() if df is not None else 'No data')
PY` *(fails: HTTPSConnectionPool(host='fbrapi.com', port=443): Max retries exceeded with url: /league-standings?league_id=9&season_id=2023-24 (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*

------
https://chatgpt.com/codex/tasks/task_e_68b7435a6ad4832999487726a2cf858b