### PR TITLE
Store raw FBR API responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Results are cached to JSON files in `utils/poisson_utils/xg_sources/`:
 - `xg_cache.json` stores the final aggregated results
 - `understat_xg_cache.json`, `fbrapi_xg_cache.json` and `fbref_xg_cache.json`
   keep provider‑specific responses
+- raw responses from the FBR API are stored in the `fbrapi_raw` directory for
+  debugging and inspection
 
 FBR API requests require an API key provided via the environment variable
 `FBRAPI_KEY`.


### PR DESCRIPTION
## Summary
- persist raw FBR API responses to `utils/poisson_utils/xg_sources/fbrapi_raw`
- document where raw FBR API data is saved

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb1f158674832990ad2961544987dc