### PR TITLE
feat: train RF model using local CSV data

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,16 +140,18 @@ Hyperparametry se hledají pomocí `RandomizedSearchCV` optimalizovaného na
 `log_loss`. Skript po dokončení vypíše také Brierovy skóre a kalibrační křivky
 pro jednotlivé třídy. Parametry křížové validace i rozsah vyhledávání
 hyperparametrů lze upravit pomocí argumentů příkazové řádky:
-=======
-Parametry křížové validace i rozsah vyhledávání hyperparametrů lze upravit
-pomocí argumentů příkazové řádky:
 
 ```bash
-python scripts/train_models.py --n-iter 20 --n-splits 5 --recent-years 2
+python scripts/train_models.py --data-dir data --n-iter 20 --n-splits 5 --recent-years 2
 ```
 
 Volitelný argument `--max-samples` může omezit počet zpracovaných zápasů pro
 rychlé experimenty.
+
+Protože základní CSV data neobsahují oficiální hodnoty očekávaných gólů,
+skript při načítání vytváří jednoduchý pseudo‑xG ukazatel ze střel a střel na
+branku (0.1 × střely + 0.3 × střely na branku). Statistiky držení míče se
+ignorují.
 
 ## ✅ Testy
 

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -2,10 +2,10 @@
 
 import argparse
 
-from fbrapi_dataset import build_three_seasons
 from utils.ml.random_forest import (
     DEFAULT_MODEL_PATH,
     DEFAULT_OVER25_MODEL_PATH,
+    load_csv_data,
     save_model,
     train_model,
     train_over25_model,
@@ -14,15 +14,18 @@ from utils.ml.random_forest import (
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Train Random Forest models")
-    parser.add_argument("--league-id", type=int, required=True)
-    parser.add_argument("--seasons", nargs="+", required=True, help="Season identifiers from FBR API")
+    parser.add_argument(
+        "--data-dir",
+        default="data",
+        help="Directory containing *_combined_full_updated.csv files",
+    )
     parser.add_argument("--n-splits", type=int, default=3)
     parser.add_argument("--recent-years", type=int, default=1)
     parser.add_argument("--n-iter", type=int, default=1)
     parser.add_argument("--max-samples", type=int, default=500)
     args = parser.parse_args()
 
-    df = build_three_seasons(args.league_id, args.seasons)
+    df = load_csv_data(args.data_dir)
 
     model, features, le, score, params, metrics = train_model(
         df,


### PR DESCRIPTION
## Summary
- Engineer new Random Forest metrics like goal balance, shot accuracy, conversion rate and defensive compactness from local CSV data
- Streamline feature set by removing redundant possession and conceded stats for cleaner training
- Apply the richer metrics when constructing features for match predictions
- Derive pseudo expected goals from shot data to avoid duplicating goal stats

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc312d372083298d60f9ecaed8173d